### PR TITLE
Allow puppet to use Array's for properties with , in the name.

### DIFF
--- a/lib/puppet/type/shared/target.rb
+++ b/lib/puppet/type/shared/target.rb
@@ -10,5 +10,5 @@ newproperty(:target, :array_matching => :all) do
 end
 
 def target
-  self[:target].join(',')
+  self[:targettype] ? self[:target].join(',') : ''
 end

--- a/lib/puppet/type/shared/targettype.rb
+++ b/lib/puppet/type/shared/targettype.rb
@@ -10,6 +10,6 @@ newproperty(:targettype, :array_matching => :all) do
 end
 
 def targettype
-  self[:targettype].join(',')
+  self[:targettype] ? self[:targettype].join(',') : ''
 end
 

--- a/lib/puppet/type/wls_cluster/servers.rb
+++ b/lib/puppet/type/wls_cluster/servers.rb
@@ -11,6 +11,6 @@ newproperty(:servers, :array_matching => :all) do
 end
 
 def servers
-  self[:servers].join(',')
+  self[:servers] ? self[:servers].join(',') : ''
 end
 


### PR DESCRIPTION
Allows use of array's in puppet without changing any of the python file. I've changed `target`, `targettype` and  `server`. Maybe more need/can change.

If you specify a string with `,` Puppet will notice a change, but still work.
