### PR TITLE
WLS_Datasource Fixes and Enhancements

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2660,6 +2660,9 @@ or use puppet resource wls_datasource
       url                        => 'jdbc:mysql://10.10.10.10:3306/jms',
       user                       => 'jms',
       usexa                      => '1',
+      # To Optionally Configure as Gridlink Datasource
+      fanenabled:                => '1',
+      onsnodelist:               => '10.10.10.110:6200,10.10.10.111:6200',
     }
 
 in hiera
@@ -2707,7 +2710,9 @@ in hiera
           url:                         'jdbc:mysql://10.10.10.10:3306/jms'
           user:                        'jms'
           usexa:                       '1'
-
+          # To Optionally Configure as Gridlink Datasource
+          fanenabled:                  '1'
+          onsnodelist:                 '10.10.10.110:6200,10.10.10.111:6200'
 
 ### wls_jms_module
 

--- a/files/providers/wls_datasource/create.py.erb
+++ b/files/providers/wls_datasource/create.py.erb
@@ -18,6 +18,8 @@ extraproperties            = '<%= extraproperties %>'
 extrapropertiesvalues      = '<%= extrapropertiesvalues %>'
 maxcapacity                = '<%= maxcapacity %>'
 initialcapacity            = '<%= initialcapacity %>'
+fanenabled                 = '<%= fanenabled %>'
+onsnodelist                = '<%= onsnodelist %>'
 
 
 edit()
@@ -72,6 +74,16 @@ try:
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCDataSourceParams/' + name)
     cmo.setGlobalTransactionsProtocol(globaltransactionsprotocol)
+
+    try:
+        cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCOracleParams/' + name )
+        if fanenabled == '1':
+            cmo.setFanEnabled(true)
+        else:
+            cmo.setFanEnabled(false)
+        cmo.setOnsNodeList(onsnodelist)
+    except:
+        print "Datasource Driver %s does not support ONS parameters." % drivername
 
     cd('/SystemResources/' + name )
 

--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -9,7 +9,7 @@ def quote(text):
 m = ls('/JDBCSystemResources',returnMap='true')
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;target;targettype;drivername;jndinames;url;usexa;user;testtablename;globaltransactionsprotocol;extraproperties;extrapropertiesvalues;maxcapacity;initialcapacity;domain"
+print >>f, "name;target;targettype;drivername;jndinames;url;usexa;user;testtablename;globaltransactionsprotocol;extraproperties;extrapropertiesvalues;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist"
 for token in m:
         print '___'+token+'___'
         cd('/JDBCSystemResources/'+token + '/JDBCResource/' + token)
@@ -38,6 +38,16 @@ for token in m:
         cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDataSourceParams/' + token)
         globalTransactionsProtocol = get('GlobalTransactionsProtocol')
 
+        
+        try:
+            cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCOracleParams/' + token )
+            fanenabled = str(get('FanEnabled'))
+            onsnodelist = get('OnsNodeList')
+        except:
+            # In Case any Datasource Type does not include JDBCOracleParams
+            fanenabled = '0'
+            onsnodelist = ''
+
         p = ls('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDriverParams/' + token + '/Properties/' + token + '/Properties',returnMap='true')
         properties     = []
         propertyValues = []
@@ -55,6 +65,6 @@ for token in m:
                cd('/SystemResources/'+token+'/Targets/'+token2)
                targetType.append(get('Type'))
 
-        print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,user,testTableName,globalTransactionsProtocol,','.join(properties),','.join(propertyValues),maxcapacity,initialcapacity,domain]))
+        print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,user,testTableName,globalTransactionsProtocol,','.join(properties),','.join(propertyValues),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist]))
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_datasource/modify.py.erb
+++ b/files/providers/wls_datasource/modify.py.erb
@@ -2,7 +2,6 @@
 real_domain='<%= domain %>'
 
 
-
 name                       = '<%= datasource_name %>'
 target                     = '<%= target %>'
 targettype                 = '<%= targettype %>'
@@ -17,7 +16,8 @@ extraproperties            = '<%= extraproperties %>'
 extrapropertiesvalues      = '<%= extrapropertiesvalues %>'
 maxcapacity                = '<%= maxcapacity %>'
 initialcapacity            = '<%= initialcapacity %>'
-
+fanenabled                 = '<%= fanenabled %>'
+onsnodelist                = '<%= onsnodelist %>'
 
 edit()
 startEdit()
@@ -46,15 +46,23 @@ try:
     set('MaxCapacity'    , int(maxcapacity))
     set('InitialCapacity', int(initialcapacity))
 
-
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCDriverParams/' + name + '/Properties/' + name + '/Properties/user')
     cmo.setValue(user)
 
+
+    # Remove Existing Properties First
+    cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCDriverParams/' + name + '/Properties/' + name + '/Properties/')
+    existing_properties = ls('', returnMap='true')
+    for existing_prop in existing_properties:
+        if existing_prop.lower() != 'user':
+            cmo.destroyProperty(cmo.lookupProperty(existing_prop))
+
     if extraproperties:
       if extrapropertiesvalues:
+          # Create Properties From Config
           properties=String(extraproperties).split(",")
           values=String(extrapropertiesvalues).split(",")
 
@@ -73,6 +81,16 @@ try:
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCDataSourceParams/' + name)
     cmo.setGlobalTransactionsProtocol(globaltransactionsprotocol)
+
+    try:
+        cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCOracleParams/' + name )
+        if fanenabled == '1':
+            cmo.setFanEnabled(true)
+        else:
+            cmo.setFanEnabled(false)
+        cmo.setOnsNodeList(onsnodelist)
+    except:
+        print "Datasource Driver %s does not support ONS parameters." % drivername
 
     cd('/SystemResources/' + name )
 

--- a/lib/puppet/type/wls_datasource.rb
+++ b/lib/puppet/type/wls_datasource.rb
@@ -56,6 +56,8 @@ module Puppet
     property  :extrapropertiesvalues
     property  :maxcapacity
     property  :initialcapacity
+    property  :fanenabled
+    property  :onsnodelist
 
     add_title_attributes( :datasource_name) do 
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_datasource/fanenabled.rb
+++ b/lib/puppet/type/wls_datasource/fanenabled.rb
@@ -1,0 +1,14 @@
+newproperty(:fanenabled) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  desc "Enables the data source to subscribe to and process Oracle FAN events."
+  newvalues(1, 0)
+
+  defaultto '0'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['fanenabled']
+  end
+
+end

--- a/lib/puppet/type/wls_datasource/onsnodelist.rb
+++ b/lib/puppet/type/wls_datasource/onsnodelist.rb
@@ -1,0 +1,10 @@
+newproperty(:onsnodelist) do
+  include EasyType
+
+  desc "A comma-separate list of ONS daemon listen addresses and ports to which connect to for receiving ONS-based FAN events"
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['onsnodelist']
+  end
+
+end


### PR DESCRIPTION
Hi Edwin,

Here are a couple of changes to the wls_datasource type:
1. Added FAN Enabled flag and ONS Node List parameter to enable creation of Gridlink datasources
2. Updated modify action to remove existing extraproperties from the datasource before considering the extraproperties value. This fixes a problem where an extraproperty can be defined during create, then removed from the Puppet config yet it still persists in the WL config.

I added a conditional to avoid removing the "user" property during this purge of extraproperties.

Let me know if you find any issues.

Cheers,
Brad
