### PR TITLE
Automatic sorting of authentication providers

### DIFF
--- a/files/providers/wls_authentication_provider/create.py.erb
+++ b/files/providers/wls_authentication_provider/create.py.erb
@@ -1,13 +1,11 @@
 # check the domain else we need to skip this (done in wls_access.rb)
 real_domain='<%= domain %>'
 
-
 name                      = '<%= authentication_provider_name %>'
 control_flag              = '<%= control_flag %>'
 providerclassname         = '<%= providerclassname %>'
 attributes                = '<%= attributes %>'
 attributesvalues          = '<%= attributesvalues %>'
-
 
 edit()
 startEdit()
@@ -21,12 +19,19 @@ try:
 
     cmo.createAuthenticationProvider(name, providerclassname)
 
-    cd('AuthenticationProviders/'+name)
+    cd ('AuthenticationProviders/' + name)
+
+    pwd()
+    ls()
+
     if control_flag:
+      print name + ": control_flag is set: >" + control_flag + "<"
       cmo.setControlFlag(control_flag)
 
     if attributes:
+      print name + ": attributes is set: >" + attributes + "<"
       if attributesvalues:
+          print name + " attributesvalues is set: >" + attributesvalues + "<"
           properties=String(attributes).split(";")
           values=String(attributesvalues).split(";")
 
@@ -75,6 +80,27 @@ try:
               set(property,values[i])
 
             i = i + 1
+
+    save()
+    #
+    #   sort auth providers
+    #
+    cd('/SecurityConfiguration/' + real_domain + '/Realms/' + realmName.getName())
+    authprovs = cmo.getAuthenticationProviders()
+
+    ap_array = []
+
+    for ap in authprovs:
+      ap_name = ap.getName()
+      if ap_name == name:
+        ap_array.append(ObjectName('Security:Name=' + realmName.getName() + ap_name))
+
+    for ap in authprovs:
+      ap_name = ap.getName()
+      if ap_name != name:
+        ap_array.append(ObjectName('Security:Name=' + realmName.getName() + ap_name))
+
+    set('AuthenticationProviders', jarray.array(ap_array, ObjectName))
 
     save()
     activate()


### PR DESCRIPTION
Automatic sorting of authentication providers, the current auth-provider
that is processed will be first on the list. So you can use 'require:'
the the hiera file to force the sequence.
