### PR TITLE
Added sleep parameter with 20 second default to nodemanager

### DIFF
--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -139,7 +139,7 @@ define orawls::nodemanager (
   }
 
   exec { "sleep ${sleep} sec for wlst exec ${title}":
-      command     => '/bin/sleep ${sleep}',
+      command     => "/bin/sleep ${sleep}",
       subscribe   => Exec["startNodemanager ${title}"],
       refreshonly => true,
       path        => $exec_path,


### PR DESCRIPTION
10.3.6 Node managers load slower than 12.1.2 and need a longer sleep.
