### PR TITLE
Added addtional settings for  managed servers / admin server

### DIFF
--- a/files/providers/wls_server/create.py.erb
+++ b/files/providers/wls_server/create.py.erb
@@ -8,6 +8,8 @@ machineName   = '<%= machine %>'
 
 logFilename                 = '<%= logfilename %>'
 log_http_Filename           = '<%= log_http_filename %>'
+log_http_format             = '<%= log_http_format %>'
+log_http_format_type        = '<%= log_http_format_type %>'
 log_datasource_Filename     = '<%= log_datasource_filename %>'
 log_file_min_size           = '<%= log_file_min_size %>'
 log_filecount               = '<%= log_filecount %>'
@@ -24,6 +26,7 @@ client_certificate_enforced = <%= client_certificate_enforced %>
 sslListenPort = <%= ssllistenport %>
 
 jsseenabled   = <%= jsseenabled %>
+tunnelingenabled     = <%= tunnelingenabled %>
 
 custom_identity                        = '<%= custom_identity %>'
 custom_identity_keystore_filename      = '<%= custom_identity_keystore_filename %>'
@@ -65,24 +68,29 @@ def formatBoolean2(value):
 try:
 
     cd('/')
-    cmo.createServer(name)
+    if name != 'AdminServer':
+      cmo.createServer(name)
 
     cd('/Servers/'+name)
     set('Machine',getMBean('/Machines/'+machineName))
 
-    if listenAddress:
-        set('ListenAddress',listenAddress)
+    if listenAddress and not listenAddress.isspace():
+      set('ListenAddress',listenAddress)
 
-    set('ListenPort', listenPort)
+    if listenPort:
+      set('ListenPort', listenPort)
 
     if max_message_size:
       set('MaxMessageSize',max_message_size)
 
     if classpath:
-        set('ServerStart/'+name+'/ClassPath', classpath)
+      set('ServerStart/'+name+'/ClassPath', classpath)
 
     if arguments:
-        set('ServerStart/'+name+'/Arguments', arguments)
+      set('ServerStart/'+name+'/Arguments', arguments)
+
+    if tunnelingenabled:
+      set('TunnelingEnabled', tunnelingenabled)
 
     if custom_identity == '1':
       set('KeyStores'                                ,'CustomIdentityAndCustomTrust')
@@ -93,20 +101,23 @@ try:
       cd('SSL/'+name)
       set('ServerPrivateKeyAlias'                    ,custom_identity_alias)
       set('ServerPrivateKeyPassPhrase'               ,custom_identity_privatekey_passphrase)
-    else:
+    if custom_identity == '0':
       set('KeyStores'                                ,'DemoIdentityAndDemoTrust')
 
     cd('/Servers/'+name+'/SSL/'+name)
 
-    set('Enabled', formatBoolean(sslEnabled))
-
-    set('JSSEEnabled', formatBoolean(jsseenabled))
-
-    set('HostnameVerificationIgnored', formatBoolean(sslHostnameVerificationIgnored))
-    set('TwoWaySSLEnabled'           , formatBoolean(two_way_ssl))
-    set('ClientCertificateEnforced'  , formatBoolean(client_certificate_enforced))
-
-    set('ListenPort', sslListenPort)
+    if sslEnabled and sslEnabled != -1:
+      set('Enabled', formatBoolean(sslEnabled))
+    if jsseenabled and jsseenabled != -1:
+      set('JSSEEnabled', formatBoolean(jsseenabled))
+    if sslHostnameVerificationIgnored and sslHostnameVerificationIgnored != -1:
+      set('HostnameVerificationIgnored', formatBoolean(sslHostnameVerificationIgnored))
+    if two_way_ssl:
+      set('TwoWaySSLEnabled'           , formatBoolean(two_way_ssl))
+    if client_certificate_enforced:
+      set('ClientCertificateEnforced'  , formatBoolean(client_certificate_enforced))
+    if sslListenPort:
+      set('ListenPort', sslListenPort)
 
     cd('/Servers/'+name+'/Log/'+name)
     if logFilename:
@@ -136,6 +147,10 @@ try:
       cmo.setNumberOfFilesLimited(int(log_number_of_files_limited))
     if log_file_min_size:
       cmo.setFileMinSize(int(log_file_min_size))
+    if log_http_format_type:
+      cmo.setLogFileFormat(log_http_format_type)
+    if log_http_format:
+      cmo.setELFFields(log_http_format)
 
     print "datasource server log: " + name
     cd('/Servers/'+name+'/DataSource/'+name+'/DataSourceLogFile/'+name)
@@ -153,7 +168,8 @@ try:
       cmo.setFileMinSize(int(log_file_min_size))
 
     cd('/Servers/'+name+'/DefaultFileStore/'+name)
-    cmo.setDirectory(default_file_store)
+    if default_file_store:
+      cmo.setDirectory(default_file_store)
 
     cd('/')
     DOMAIN_PATH = get('RootDirectory')

--- a/files/providers/wls_server/index.py.erb
+++ b/files/providers/wls_server/index.py.erb
@@ -10,13 +10,14 @@ cd("/")
 m = ls('/Servers',returnMap='true')
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;listenaddress;listenport;ssllistenport;sslenabled;sslhostnameverificationignored;two_way_ssl;client_certificate_enforced;machine;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_number_of_files_limited;log_http_filename;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size"
+print >>f, "name;listenaddress;listenport;ssllistenport;sslenabled;sslhostnameverificationignored;two_way_ssl;client_certificate_enforced;machine;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_number_of_files_limited;tunnelingenabled;log_http_filename;log_http_format;log_http_format_type;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size"
 for token in m:
   print '___'+token+'___'
   cd('/Servers/'+token)
   listenAddress    = get('ListenAddress')
   listenPort       = str(get('ListenPort'))
   max_message_size = str(get('MaxMessageSize'))
+  tunnelingenabled = str(get('TunnelingEnabled'))
 
   if get("KeyStores") == "CustomIdentityAndCustomTrust":
     custom_identity = '1'
@@ -25,7 +26,6 @@ for token in m:
 
   custom_identity_keystore_filename = get("CustomIdentityKeyStoreFileName")
   trust_keystore_file               = get("CustomTrustKeyStoreFileName")
-
 
   cd('/Servers/'+token+'/SSL/'+token)
   sslListenPort                     = str(get('ListenPort'))
@@ -55,7 +55,9 @@ for token in m:
   log_file_min_size           = str(get('FileMinSize'))
 
   cd('/Servers/'+token+'/WebServer/'+token+'/WebServerLog/'+token)
-  log_http_filename                = get('FileName')
+  log_http_filename           = get('FileName')
+  log_http_format             = get('ELFFields')
+  log_http_format_type        = get('LogFileFormat')
 
   cd('/Servers/'+token+'/DataSource/'+token+'/DataSourceLogFile/'+token)
   log_datasource_filename          = get('FileName')
@@ -70,7 +72,7 @@ for token in m:
       if token2:
          machine = token2
 
-  print >>f, ";".join(map(quote, [domain+'/'+token, listenAddress, listenPort, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, two_way_ssl, client_certificate_enforced, machine, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_number_of_files_limited, log_http_filename,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size]))
+  print >>f, ";".join(map(quote, [domain+'/'+token, listenAddress, listenPort, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, two_way_ssl, client_certificate_enforced, machine, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_number_of_files_limited, tunnelingenabled,log_http_filename,log_http_format,log_http_format_type,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size]))
 
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_server/modify.py.erb
+++ b/files/providers/wls_server/modify.py.erb
@@ -1,8 +1,6 @@
 # check the domain else we need to skip this (done in wls_access.rb)
 real_domain='<%= domain %>'
 
-
-
 name          = '<%= server_name %>'
 classpath     = '<%= classpath %>'
 arguments     = '''<%= arguments %>'''
@@ -16,6 +14,8 @@ log_rotationtype            = '<%= log_rotationtype %>'
 log_number_of_files_limited = '<%= log_number_of_files_limited %>'
 
 log_http_Filename           = '<%= log_http_filename %>'
+log_http_format             = '<%= log_http_format %>'
+log_http_format_type        = '<%= log_http_format_type %>'
 log_datasource_Filename     = '<%= log_datasource_filename %>'
 
 listenAddress = '<%= listenaddress %>'
@@ -28,6 +28,8 @@ sslListenPort = <%= ssllistenport %>
 
 jsseenabled   = <%= jsseenabled %>
 
+tunnelingenabled = <%= tunnelingenabled %>
+
 custom_identity                        = '<%= custom_identity %>'
 custom_identity_keystore_filename      = '<%= custom_identity_keystore_filename %>'
 custom_identity_keystore_passphrase    = '<%= custom_identity_keystore_passphrase %>'
@@ -38,7 +40,6 @@ trust_keystore_passphrase              = '<%= trust_keystore_passphrase %>'
 
 default_file_store                     = '<%= default_file_store %>'
 max_message_size                       = '<%= max_message_size %>'
-
 
 def format(value):
     if (value):
@@ -64,18 +65,26 @@ startEdit()
 try:
 
     cd('/Servers/'+name)
-    set('Machine',getMBean('/Machines/'+machineName))
+    if name != 'AdminServer':
+      set('Machine',getMBean('/Machines/'+machineName))
 
-    set('ListenAddress', format(listenAddress))
+    if listenAddress and not listenAddress.isspace():
+      set('ListenAddress', format(listenAddress))
 
-    set('ListenPort', format(listenPort))
+    if listenPort:
+      set('ListenPort', format(listenPort))
+
+    if tunnelingenabled:
+      set('TunnelingEnabled', tunnelingenabled)
 
     if max_message_size:
       set('MaxMessageSize',max_message_size)
 
-    set('ServerStart/'+name+'/ClassPath', format(classpath))
+    if classpath:
+      set('ServerStart/'+name+'/ClassPath', format(classpath))
 
-    set('ServerStart/'+name+'/Arguments', format(arguments))
+    if arguments:
+      set('ServerStart/'+name+'/Arguments', format(arguments))
 
     if custom_identity == '1':
       set('KeyStores'                                ,'CustomIdentityAndCustomTrust')
@@ -86,20 +95,25 @@ try:
       cd('SSL/'+name)
       set('ServerPrivateKeyAlias'                    ,custom_identity_alias)
       set('ServerPrivateKeyPassPhrase'               ,custom_identity_privatekey_passphrase)
-    else:
+    if custom_identity == '0':
       set('KeyStores'                                ,'DemoIdentityAndDemoTrust')
 
     cd('/Servers/'+name+'/SSL/'+name)
 
-    set('Enabled', formatBoolean(sslEnabled))
+    if sslEnabled and sslEnabled != -1:
+      set('Enabled', formatBoolean(sslEnabled))
+    if jsseenabled and jsseenabled != -1:
+      set('JSSEEnabled',formatBoolean(jsseenabled))
 
-    set('JSSEEnabled',formatBoolean(jsseenabled))
+    if sslHostnameVerificationIgnored and sslHostnameVerificationIgnored != -1:
+      set('HostnameVerificationIgnored', formatBoolean(sslHostnameVerificationIgnored))
+    if two_way_ssl:
+      set('TwoWaySSLEnabled'           , formatBoolean(two_way_ssl))
+    if client_certificate_enforced:
+      set('ClientCertificateEnforced'  , formatBoolean(client_certificate_enforced))
 
-    set('HostnameVerificationIgnored', formatBoolean(sslHostnameVerificationIgnored))
-    set('TwoWaySSLEnabled'           , formatBoolean(two_way_ssl))
-    set('ClientCertificateEnforced'  , formatBoolean(client_certificate_enforced))
-
-    set('ListenPort', sslListenPort)
+    if sslListenPort:
+      set('ListenPort', sslListenPort)
 
     cd('/Servers/'+name+'/Log/'+name)
     if logFilename:
@@ -128,6 +142,10 @@ try:
       cmo.setNumberOfFilesLimited(int(log_number_of_files_limited))
     if log_file_min_size:
       cmo.setFileMinSize(int(log_file_min_size))
+    if log_http_format_type:
+      cmo.setLogFileFormat(log_http_format_type)
+    if log_http_format:
+      cmo.setELFFields(log_http_format)
 
     cd('/Servers/'+name+'/DataSource/'+name+'/DataSourceLogFile/'+name)
     if log_datasource_Filename:
@@ -144,7 +162,8 @@ try:
       cmo.setFileMinSize(int(log_file_min_size))
 
     cd('/Servers/'+name+'/DefaultFileStore/'+name)
-    cmo.setDirectory(default_file_store)
+    if default_file_store:
+      cmo.setDirectory(default_file_store)
 
     save()
     activate()

--- a/lib/puppet/type/wls_server.rb
+++ b/lib/puppet/type/wls_server.rb
@@ -47,7 +47,7 @@ module Puppet
     parameter :trust_keystore_passphrase
     parameter :timeout
 
-    property :custom_identity
+    property :tunnelingenabled
 
     property :trust_keystore_file
     property :custom_identity_keystore_filename
@@ -69,6 +69,8 @@ module Puppet
     property :log_rotate_logon_startup
 
     property :log_http_filename
+    property :log_http_format_type
+    property :log_http_format
     property :log_datasource_filename
 
     property :sslhostnameverificationignored
@@ -77,6 +79,8 @@ module Puppet
     property :jsseenabled
     property :default_file_store
     property :max_message_size
+
+    property :custom_identity
 
     add_title_attributes(:server_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_server/custom_identity.rb
+++ b/lib/puppet/type/wls_server/custom_identity.rb
@@ -2,9 +2,9 @@ newproperty(:custom_identity) do
   include EasyType
 
   desc 'The custom_identity true or false'
-  newvalues('1', '0')
+  newvalues('1', '0', '-1')
 
-  defaultto '0'
+  defaultto '-1'
 
   to_translate_to_resource do | raw_resource|
     raw_resource['custom_identity']

--- a/lib/puppet/type/wls_server/jsseenabled.rb
+++ b/lib/puppet/type/wls_server/jsseenabled.rb
@@ -2,9 +2,9 @@ newproperty(:jsseenabled) do
   include EasyType
 
   desc 'The JSSE eenabled enabled on the server'
-  newvalues('1', '0')
+  newvalues('1', '0', '-1')
 
-  defaultto '0'
+  defaultto '-1'
 
   to_translate_to_resource do | raw_resource|
     raw_resource['jsseenabled']

--- a/lib/puppet/type/wls_server/log_http_format.rb
+++ b/lib/puppet/type/wls_server/log_http_format.rb
@@ -1,0 +1,10 @@
+newproperty(:log_http_format) do
+  include EasyType
+
+  desc 'The log http format of the file name of the server'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['log_http_format']
+  end
+
+end

--- a/lib/puppet/type/wls_server/log_http_format_type.rb
+++ b/lib/puppet/type/wls_server/log_http_format_type.rb
@@ -1,0 +1,10 @@
+newproperty(:log_http_format_type) do
+  include EasyType
+
+  desc 'The log format type of the  http file name of the server'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['log_http_format_type']
+  end
+
+end

--- a/lib/puppet/type/wls_server/sslenabled.rb
+++ b/lib/puppet/type/wls_server/sslenabled.rb
@@ -2,7 +2,9 @@ newproperty(:sslenabled) do
   include EasyType
 
   desc 'The ssl enabled on the server'
-  newvalues('1', '0')
+  newvalues('1', '0', '-1')
+
+  defaultto '-1'
 
   to_translate_to_resource do | raw_resource|
     raw_resource['sslenabled']

--- a/lib/puppet/type/wls_server/sslhostnameverificationignored.rb
+++ b/lib/puppet/type/wls_server/sslhostnameverificationignored.rb
@@ -2,7 +2,9 @@ newproperty(:sslhostnameverificationignored) do
   include EasyType
 
   desc 'The ssl hostname verification ignored enabled on the server'
-  newvalues(1, 0)
+  newvalues(1, 0, -1)
+
+  defaultto -1
 
   to_translate_to_resource do | raw_resource|
     raw_resource['sslhostnameverificationignored']

--- a/lib/puppet/type/wls_server/tunnelingenabled.rb
+++ b/lib/puppet/type/wls_server/tunnelingenabled.rb
@@ -1,0 +1,14 @@
+newproperty(:tunnelingenabled) do
+  include EasyType
+
+  desc 'Enable tunneling to the server'
+
+  newvalues('1', '0')
+
+  defaultto '0'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['tunnelingenabled']
+  end
+
+end


### PR DESCRIPTION
Added settings for tunneling, log format for access files (such as
extended)
Note: also refined wls_server properties; Not all properties are needed;
Example:

server_instances:
'AdminServer':
    ensure:                                'present'

tunnelingenabled:                      '1'
    logfilename:
"%{hiera('wls_log_dir')}/AdminServer.log"
    log_http_filename:
"%{hiera('wls_log_dir')}/AdminServer.access"

log_datasource_filename:
"%{hiera('wls_log_dir')}/AdminServer.ds"
    log_rotationtype:
"none"
    log_http_format_type:                  "extended"

log_http_format:                       "date time x-XForwardedFor s-ip
cs-method cs-uri x-SOAPAction sc-status bytes time-taken x-UserAgent"
