### PR TITLE
Fix ps binary path and arguments for Solaris 11

### DIFF
--- a/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
+++ b/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
@@ -57,11 +57,12 @@ EOF"
     domain_name    = resource[:domain_name]
     name           = resource[:server_name]
 
-    if :kernel == 'SunOS'
-      command  = "/usr/ucb/ps wwxa | grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
-    else
-      command  = "/bin/ps -ef | grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
-    end
+    kernel = Facter.value(:kernel)
+
+    ps_bin = (kernel != "SunOS" || (kernel == 'SunOS' && Facter.value(:kernelrelease) == '5.11')) ? "/bin/ps" : "/usr/ucb/ps"
+    ps_arg = kernel == "SunOS" ? "awwx" : "-ef"
+
+    command  = "#{ps_bin} #{ps_arg} | /bin/grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
 
     Puppet.debug "adminserver_status #{command}"
     output = `#{command}`

--- a/lib/puppet/provider/wls_managedserver/wls_managedserver.rb
+++ b/lib/puppet/provider/wls_managedserver/wls_managedserver.rb
@@ -38,11 +38,12 @@ EOF"
     domain_name    = resource[:domain_name]
     name           = resource[:server_name]
 
-    if :kernel == 'SunOS'
-      command  = "/usr/ucb/ps wwxa | grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
-    else
-      command  = "/bin/ps -ef | grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
-    end
+    kernel = Facter.value(:kernel)
+
+    ps_bin = (kernel != "SunOS" || (kernel == 'SunOS' && Facter.value(:kernelrelease) == '5.11')) ? "/bin/ps" : "/usr/ucb/ps"
+    ps_arg = kernel == "SunOS" ? "awwx" : "-ef"
+
+    command  = "#{ps_bin} #{ps_arg} | /bin/grep -v grep | /bin/grep 'weblogic.Name=#{name}' | /bin/grep #{domain_name}"
 
     Puppet.debug "managedserver_status #{command}"
     output = `#{command}`

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -84,13 +84,20 @@ define orawls::nodemanager (
       $java_statement = 'java'
     }
     'SunOS': {
-      $checkCommand   = "/usr/ucb/ps wwxa | grep -v grep | /bin/grep 'weblogic.NodeManager'"
+      case $::kernelrelease {
+        '5.11': {
+          $checkCommand   = "/bin/ps wwxa | /bin/grep -v grep | /bin/grep 'weblogic.NodeManager'"
+        }
+        default: {
+          $checkCommand   = "/usr/ucb/ps wwxa | /bin/grep -v grep | /bin/grep 'weblogic.NodeManager'"
+        }
+      }
       $nativeLib      = 'solaris/x64'
       $suCommand      = "su - ${os_user}"
       $java_statement = 'java -d64'
     }
     default: {
-      fail("Unrecognized operating system ${::kernel}, please use it on a Linux host")
+      fail("Unrecognized operating system ${::kernel}, please use it on a Linux or Solaris host")
     }
   }
 

--- a/manifests/oud/control.pp
+++ b/manifests/oud/control.pp
@@ -18,10 +18,17 @@ define orawls::oud::control(
       $checkCommand = "/bin/ps -ef | grep -v grep | /bin/grep '${oud_instances_home_dir}/${oud_instance_name}/OUD'"
     }
     'SunOS': {
-      $checkCommand = "/usr/ucb/ps wwxa | grep -v grep | /bin/grep '${oud_instances_home_dir}/${oud_instance_name}/OUD'"
+      case $::kernelrelease {
+        '5.11': {
+          $checkCommand = "/bin/ps wwxa | /bin/grep -v grep | /bin/grep '${oud_instances_home_dir}/${oud_instance_name}/OUD'"
+        }
+        default: {
+          $checkCommand = "/usr/ucb/ps wwxa | /bin/grep -v grep | /bin/grep '${oud_instances_home_dir}/${oud_instance_name}/OUD'"
+        }
+      }
     }
     default: {
-      fail("Unrecognized operating system ${::kernel}, please use it on a Linux host")
+      fail("Unrecognized operating system ${::kernel}, please use it on a Linux or Solaris host")
     }
   }
 


### PR DESCRIPTION
On Solaris 10 the path to BSD ps(1B) is /usr/ucb/ps. On Solaris 11 the
BSD compatibility tools are not installed by default, and ps(1) has been
updated to detect BSD-style arguments and emulate the corresponding
behaviour automatically. Therefore path can be changed to /bin/ps for
Solaris 11 versus /usr/ucb/ps for Solaris 10.

Also changed the way Facter fact, kernel, is obtained as using a Ruby
symbol for the fact resulted in the literal string "kernel" as opposed
to the anticipated fact value, i.e. "SunOS".
