### PR TITLE
Autorequire on all top level objects

### DIFF
--- a/lib/puppet/type/wls_foreign_server.rb
+++ b/lib/puppet/type/wls_foreign_server.rb
@@ -54,5 +54,10 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
   end
 end

--- a/lib/puppet/type/wls_foreign_server_object.rb
+++ b/lib/puppet/type/wls_foreign_server_object.rb
@@ -52,5 +52,12 @@ module Puppet
       /^((.*\/)?(.*):(.*):(.*)?)$/
     end
 
+
+    #
+    # Make sure the top foreign server is auto required
+    #
+    autorequire(:wls_foreign_server) { "#{jmsmodule}:#{foreign_server}"}
+
+
   end
 end

--- a/lib/puppet/type/wls_jms_connection_factory.rb
+++ b/lib/puppet/type/wls_jms_connection_factory.rb
@@ -60,5 +60,10 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
   end
 end

--- a/lib/puppet/type/wls_jms_queue.rb
+++ b/lib/puppet/type/wls_jms_queue.rb
@@ -60,5 +60,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_jms_quota.rb
+++ b/lib/puppet/type/wls_jms_quota.rb
@@ -51,5 +51,10 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
   end
 end

--- a/lib/puppet/type/wls_jms_subdeployment.rb
+++ b/lib/puppet/type/wls_jms_subdeployment.rb
@@ -49,5 +49,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_jms_topic.rb
+++ b/lib/puppet/type/wls_jms_topic.rb
@@ -61,5 +61,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_saf_error_handler.rb
+++ b/lib/puppet/type/wls_saf_error_handler.rb
@@ -50,5 +50,10 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
   end
 end

--- a/lib/puppet/type/wls_saf_imported_destination.rb
+++ b/lib/puppet/type/wls_saf_imported_destination.rb
@@ -54,5 +54,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_saf_imported_destination_object.rb
+++ b/lib/puppet/type/wls_saf_imported_destination_object.rb
@@ -56,5 +56,11 @@ module Puppet
       /^((.*\/)?(.*):(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_saf_remote_context.rb
+++ b/lib/puppet/type/wls_saf_remote_context.rb
@@ -50,5 +50,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jms module is auto required
+    #
+    autorequire(:wls_jms_module) { jmsmodule}
+
+
   end
 end

--- a/lib/puppet/type/wls_server_channel.rb
+++ b/lib/puppet/type/wls_server_channel.rb
@@ -57,5 +57,11 @@ module Puppet
       /^((.*\/)?(.*):(.*)?)$/
     end
 
+    #
+    # Make sure the top level jserver is auto required
+    #
+    autorequire(:wls_server) { server}
+
+
   end
 end


### PR DESCRIPTION
For the resource that use a title_pattern, a toplevel object needs to be realized before the current object. This change create's autorequires for these situations
