### PR TITLE
More properties setting enabled for datasources tuning in wls_datasource

### DIFF
--- a/files/providers/wls_datasource/create.py.erb
+++ b/files/providers/wls_datasource/create.py.erb
@@ -20,6 +20,9 @@ maxcapacity                = '<%= maxcapacity %>'
 initialcapacity            = '<%= initialcapacity %>'
 fanenabled                 = '<%= fanenabled %>'
 onsnodelist                = '<%= onsnodelist %>'
+mincapacity                = '<%= mincapacity %>'
+statementcachesize         = '<%= statementcachesize %>'
+testconnectionsonreserve   = '<%= testconnectionsonreserve %>'
 
 
 edit()
@@ -49,7 +52,17 @@ try:
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     set('MaxCapacity', int(maxcapacity))
     set('InitialCapacity', int(initialcapacity))
+    
+    if mincapacity:
+       set('MinCapacity',int(mincapacity))
+    
+    if statementcachesize:
+       set('StatementCacheSize',int(statementcachesize))    
 
+    if testconnectionsonreserve and testconnectionsonreserve == '1':
+       set('TestConnectionsOnReserve','true')
+    else:
+       set('TestConnectionsOnReserve','false')
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
@@ -119,5 +132,4 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-
 

--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -9,7 +9,7 @@ def quote(text):
 m = ls('/JDBCSystemResources',returnMap='true')
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;target;targettype;drivername;jndinames;url;usexa;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist"
+print >>f, "name;target;targettype;drivername;jndinames;url;usexa;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist;mincapacity;statementcachesize;testconnectionsonreserve"
 for token in m:
     print '___'+token+'___'
     cd('/JDBCSystemResources/'+token + '/JDBCResource/' + token)
@@ -30,6 +30,13 @@ for token in m:
         initialcapacity = get('InitialCapacity')
         if not (initialcapacity):
            initialcapacity = '0'
+        mincapacity     = get('MinCapacity')
+        if not (mincapacity):
+           mincapacity 	= '0'
+        statementcachesize	= get('StatementCacheSize')
+        if not (statementcachesize):
+           statementcachesize 	= '10'
+        testconnectionsonreserve = str(get('TestConnectionsOnReserve'))
 
         cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDataSourceParams/' + token )
         jndinames = get('JNDINames')
@@ -71,6 +78,6 @@ for token in m:
                cd('/SystemResources/'+token+'/Targets/'+token2)
                targetType.append(get('Type'))
 
-        print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist]))
+        print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve]))
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_datasource/modify.py.erb
+++ b/files/providers/wls_datasource/modify.py.erb
@@ -18,6 +18,9 @@ initialcapacity            = '<%= initialcapacity %>'
 fanenabled                 = '<%= fanenabled %>'
 onsnodelist                = '<%= onsnodelist %>'
 xaproperties               = '<%= xaproperties %>'
+mincapacity                = '<%= mincapacity %>'
+statementcachesize         = '<%= statementcachesize %>'
+testconnectionsonreserve   = '<%= testconnectionsonreserve %>'
 
 edit()
 startEdit()
@@ -44,6 +47,17 @@ try:
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     set('MaxCapacity'    , int(maxcapacity))
     set('InitialCapacity', int(initialcapacity))
+    
+    if mincapacity:
+       set('MinCapacity',int(mincapacity))
+    
+    if statementcachesize:
+       set('StatementCacheSize',int(statementcachesize))    
+
+    if testconnectionsonreserve and testconnectionsonreserve == '1':
+       set('TestConnectionsOnReserve','true')
+    else:
+       set('TestConnectionsOnReserve','false')
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)

--- a/lib/puppet/type/wls_datasource.rb
+++ b/lib/puppet/type/wls_datasource.rb
@@ -59,6 +59,9 @@ module Puppet
     property :initialcapacity
     property :fanenabled
     property :onsnodelist
+    property :mincapacity
+    property :statementcachesize
+    property :testconnectionsonreserve
 
     add_title_attributes(:datasource_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_datasource/mincapacity.rb
+++ b/lib/puppet/type/wls_datasource/mincapacity.rb
@@ -1,0 +1,12 @@
+newproperty(:mincapacity) do
+  include EasyType
+
+  desc 'The min capacity of the datasource'
+
+  defaultto '1'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['mincapacity']
+  end
+
+end

--- a/lib/puppet/type/wls_datasource/statementcachesize.rb
+++ b/lib/puppet/type/wls_datasource/statementcachesize.rb
@@ -1,0 +1,12 @@
+newproperty(:statementcachesize) do
+  include EasyType
+
+  desc 'The statement cache size of the datasource'
+
+  defaultto '10'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['statementcachesize']
+  end
+
+end

--- a/lib/puppet/type/wls_datasource/testconnectionsonreserve.rb
+++ b/lib/puppet/type/wls_datasource/testconnectionsonreserve.rb
@@ -1,0 +1,12 @@
+newproperty(:testconnectionsonreserve) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  desc 'the testconnectionsonreserve enabled on the jdbc driver'
+  newvalues(1, 0)
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['testconnectionsonreserve']
+  end
+
+end


### PR DESCRIPTION
ConnectionPool properties such as mincapacity, statement cache size &
test connection on reserve can be now set via puppet by setting below:

mincapacity =
statementcachesize =
testconnectionsonreserve = '0 or 1'

If not passed will be defaults.