### PR TITLE
Added LLR to datasource global transactions protocol

### DIFF
--- a/lib/puppet/type/wls_datasource/globaltransactionsprotocol.rb
+++ b/lib/puppet/type/wls_datasource/globaltransactionsprotocol.rb
@@ -2,7 +2,7 @@ newproperty(:globaltransactionsprotocol) do
   include EasyType
 
   desc 'The global Transactions Protocol'
-  newvalues('TwoPhaseCommit', 'EmulateTwoPhaseCommit', 'OnePhaseCommit', 'None')
+  newvalues('TwoPhaseCommit', 'EmulateTwoPhaseCommit', 'OnePhaseCommit', 'LoggingLastResource', 'None')
   defaultto 'TwoPhaseCommit'
 
   to_translate_to_resource do |raw_resource|


### PR DESCRIPTION
LoggingLastResource was missing from the available options on the globaltransactionsprotocol attribute of a datasource.