### PR TITLE
Implement destroying of foreign destinations/connection factories.

### DIFF
--- a/files/providers/wls_foreign_server_object/destroy.py.erb
+++ b/files/providers/wls_foreign_server_object/destroy.py.erb
@@ -5,7 +5,7 @@ real_domain='<%= domain %>'
 
 name                   = '<%= object_name %>'
 jmsmodule              = '<%= jmsmodule %>'
-foreign_server_name    = '<%= foreign_server_name %>'
+foreign_server         = '<%= foreign_server %>'
 object_type            = '<%= object_type %>'
 
 edit()
@@ -14,11 +14,15 @@ startEdit()
 try:
 
     cd('/')
-    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ForeignServers/'+foreign_server_name)
+    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ForeignServers/'+foreign_server)
 
     if object_type == "destination":
+        remoteDestination = cmo.lookupForeignDestination(name)
+        cmo.destroyForeignDestination(remoteDestination)
 
     if object_type == "connectionfactory":
+        remoteConnectionFactory = cmo.lookupForeignConnectionFactory(name)
+        cmo.destroyForeignConnectionFactory(remoteConnectionFactory)
 
     save()
     activate()          


### PR DESCRIPTION
`ensure => 'absent'` on foreign destinations and foreign connection factories didn't work prior to this.
As my project seems to need this, I took it upon myself to implement it. If there are any issues, let me know!