### PR TITLE
Solved issue with empty log_dir in domain creation

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -259,7 +259,8 @@ define orawls::domain (
 
     if $log_dir == undef {
       $admin_nodemanager_log_dir = "${domain_dir}/servers/${adminserver_name}/logs"
-      $nodemanager_log_dir       = "${domain_dir}/nodemanager/nodemanager.log"
+      $nodeMgrLogDir             = "${domain_dir}/nodemanager/nodemanager.log"
+      
 
       $osb_nodemanager_log_dir   = "${domain_dir}/servers/osb_server1/logs"
       $soa_nodemanager_log_dir   = "${domain_dir}/servers/soa_server1/logs"

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -8,7 +8,6 @@ define orawls::nodemanager (
   $weblogic_home_dir                     = hiera('wls_weblogic_home_dir'),
   $nodemanager_port                      = hiera('domain_nodemanager_port'       , 5556),
   $nodemanager_address                   = undef,
-  $nodemanager_address                   = undef,
   $nodemanager_secure_listener           = true,
   $jsse_enabled                          = hiera('wls_jsse_enabled'              , false),
   $custom_trust                          = hiera('wls_custom_trust'              , false),


### PR DESCRIPTION
Hi Edwin,

I noticed an issue with starting nodemanager after creating a WLS 1213 domain. If log_dir is not specified, the logfile entry in the nodemanager.properties is empty. Nodemanager will then not start. 

It took me some time to figure out what was wrong due to the very descriptive error message from nodemanager, but I have fixed this.

Please consider merging this to your branch. 

Kind regards,
Bas

P.S. I also removed a duplicate entry in nodemanager.pp