### PR TITLE
wls_jms_bridge_destination - Password set when no value is passed

### DIFF
--- a/files/providers/wls_jms_bridge_destination/create.py.erb
+++ b/files/providers/wls_jms_bridge_destination/create.py.erb
@@ -28,8 +28,12 @@ try:
     cmo.setDestinationJNDIName(destinationjndi)
     cmo.setDestinationType(destinationtype)
     cmo.setInitialContextFactory(initialcontextfactory)
-    cmo.setUserName(user_name)
-    cmo.setUserPassword(password)
+    
+    if user_name:
+        cmo.setUserName(user_name)
+
+    if password:
+        cmo.setUserPassword(password)
 
     save()
     activate()

--- a/files/providers/wls_jms_bridge_destination/modify.py.erb
+++ b/files/providers/wls_jms_bridge_destination/modify.py.erb
@@ -27,8 +27,12 @@ try:
     cmo.setDestinationJNDIName(destinationjndi)
     cmo.setDestinationType(destinationtype)
     cmo.setInitialContextFactory(initialcontextfactory)
-    cmo.setUserName(user_name)
-    cmo.setUserPassword(password)
+    
+    if user_name:
+        cmo.setUserName(user_name)
+
+    if password:
+        cmo.setUserPassword(password)
 
     save()
     activate()          


### PR DESCRIPTION
For wls_jms_bridge_destination: when below is passed:
name                        = 'Destination-Source'
adapter                     = 'eis.jms.WLSConnectionFactoryJNDIXA'
classpath                   = ''
connectionfactoryjndi       = 'weblogic.jms.XAConnectionFactory'
connectionurl               = ''
destinationjndi             = 'JMS.SourceQueue'
destinationtype             = 'Queue'
initialcontextfactory       = 'weblogic.jndi.WLInitialContextFactory'
user_name                   = ''
password                    = ''

Its sets password field in WLS with some unknown value it seems.

As per WLS help:
When you set the value of this attribute, WebLogic Server does the
following:
1. Encrypts the value.
2. Sets the value of the UserPasswordEncrypted attribute to the
encrypted value.

As the value is '', not sure what it encrypts & sets in config.

For Fix, added check for user_name & password:
if user_name:
    cmo.setUserName(user_name)

if password:
    cmo.setUserPassword(password)