### PR TITLE
Multiple targets for wls_jms_module

### DIFF
--- a/files/providers/wls_jms_module/create.py.erb
+++ b/files/providers/wls_jms_module/create.py.erb
@@ -15,8 +15,16 @@ try:
     cd('/')
     cmo.createJMSSystemResource(name)
     cd('/SystemResources/'+name)
-    set('Targets', jarray.array([ObjectName('com.bea:Name='+target+',Type='+targetType)], ObjectName))
 
+    targets     = String(target).split(",")
+    targettypes = String(targetType).split(",")
+    targetList  = []
+    for i in range(len(targets)):
+      print "target "+targets[i] + " " + targettypes[i]
+      targetList.append( ObjectName('com.bea:Name=' + targets[i] + ',Type='+targettypes[i]) )
+
+    set('Targets',jarray.array(targetList, ObjectName))
+    
     save()
     activate()          
     print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_jms_module/modify.py.erb
+++ b/files/providers/wls_jms_module/modify.py.erb
@@ -14,8 +14,16 @@ try:
 
     cd('/')
     cd('/SystemResources/'+name)
-    set('Targets', jarray.array([ObjectName('com.bea:Name='+target+',Type='+targetType)], ObjectName))
+    
+    targets     = String(target).split(",")
+    targettypes = String(targetType).split(",")
+    targetList  = []
+    for i in range(len(targets)):
+      print "target "+targets[i] + " " + targettypes[i]
+      targetList.append( ObjectName('com.bea:Name=' + targets[i] + ',Type='+targettypes[i]) )
 
+    set('Targets',jarray.array(targetList, ObjectName))
+    
     save()
     activate()          
     print "~~~~COMMAND SUCCESFULL~~~~"


### PR DESCRIPTION
For wls_jms_module, the set target does not supports more than 1 target,
thus failing if more than 1 targets are passed to it.

Modified create.py & modify.py to support multiple targetting for an JMS
Module