### PR TITLE
Setting stageMode support for wls_deployment for multi-node cluster

### DIFF
--- a/files/providers/wls_deployment/create.py.erb
+++ b/files/providers/wls_deployment/create.py.erb
@@ -7,6 +7,9 @@ planpath          = '<%= planpath %>'
 target            = '<%= target %>'
 deploymenttype    = '<%= deploymenttype %>'
 versionidentifier = '<%= versionidentifier %>'
+remote            = '<%= remote %>'
+upload            = '<%= upload %>'
+stagingmode       = '<%= stagingmode %>'
 
 edit()
 startEdit()
@@ -16,21 +19,43 @@ try:
     if deploymenttype == 'Library':
       library = 'true'
     else:
-      library = 'false'  
+      library = 'false' 
+    
+    if remote == 1:
+      remoteflag = 'true'
+    else:
+      remoteflag = 'false'
+    
+    if upload == 1:
+      uploadflag = 'true'
+    else:
+      uploadflag = 'false'
 
     print 'deploying....'
     if versionidentifier:
       if planpath:
         print 'deploying with version and deploymentplan....'
-        deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote='true', upload='true',libraryModule=library,versionIdentifier=versionidentifier)
+        if stagingmode:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, stageMode=stagingmode, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
+        else:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
       else:
         print 'deploying with version without deploymentplan....'
-        deploy(appName=name, path=localpath, targets=target, remote='true', upload='true',libraryModule=library,versionIdentifier=versionidentifier)
+        if stagingmode:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
+        else:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
     else: 
       if planpath:
-        deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote='true', upload='true',libraryModule=library)
+        if stagingmode:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library)
+        else:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library)
       else:
-        deploy(appName=name, path=localpath, targets=target, remote='true', upload='true',libraryModule=library)
+        if stagingmode:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library)
+        else:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library)
 
 
     save()

--- a/files/providers/wls_deployment/index.py.erb
+++ b/files/providers/wls_deployment/index.py.erb
@@ -7,7 +7,7 @@ def quote(text):
         return ""
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;versionidentifier;deploymenttype;target;targettype;domain"
+print >>f, "name;versionidentifier;deploymenttype;stagingmode;target;targettype;domain"
 
 domainConfig()
 
@@ -20,6 +20,7 @@ for appName in myapps:
   app               = get('ApplicationName')
   deploymenttype    = get('Type')
   versionidentifier = get('VersionIdentifier')
+  stagingmode       = get('StagingMode')
 
   n = ls('/AppDeployments/'+appName.getName()+'/Targets',returnMap='true')
 
@@ -30,7 +31,7 @@ for appName in myapps:
          cd('/AppDeployments/'+appName.getName()+'/Targets/'+token2)
          targetType.append(get('Type'))
 
-  print >>f, ";".join(map(quote, [domain+'/'+app,versionidentifier,deploymenttype,','.join(target),','.join(targetType),domain]))
+  print >>f, ";".join(map(quote, [domain+'/'+app,versionidentifier,deploymenttype,stagingmode,','.join(target),','.join(targetType),domain]))
 
 print 'libs'
 cd('/')
@@ -41,6 +42,7 @@ for libName in mylibs:
   lib               = get('ApplicationName')
   deploymenttype    = get('Type')
   versionidentifier = get('VersionIdentifier')
+  stagingmode       = get('StagingMode')
 
   n = ls('/Libraries/'+libName.getName()+'/Targets',returnMap='true')
 
@@ -51,7 +53,7 @@ for libName in mylibs:
          cd('/Libraries/'+libName.getName()+'/Targets/'+token2)
          targetType.append(get('Type'))
 
-  print >>f, ";".join(map(quote, [domain+'/'+lib,versionidentifier,deploymenttype,','.join(target),','.join(targetType),domain]))
+  print >>f, ";".join(map(quote, [domain+'/'+lib,versionidentifier,deploymenttype,stagingmode,','.join(target),','.join(targetType),domain]))
 
 
 f.close()

--- a/files/providers/wls_deployment/modify.py.erb
+++ b/files/providers/wls_deployment/modify.py.erb
@@ -8,6 +8,9 @@ target            = '<%= target %>'
 targettype        = '<%= targettype %>'
 deploymenttype    = '<%= deploymenttype %>'
 versionidentifier = '<%= versionidentifier %>'
+remote            = '<%= remote %>'
+upload            = '<%= upload %>'
+stagingmode       = '<%= stagingmode %>'
 
 edit()
 startEdit()
@@ -18,6 +21,16 @@ try:
     print 'targettype....'+targettype
 
     print 'start....'
+    if remote == 1:
+      remoteflag = 'true'
+    else:
+      remoteflag = 'false'
+    
+    if upload == 1:
+      uploadflag = 'true'
+    else:
+      uploadflag = 'false'
+
     if deploymenttype == 'Library':
       library = 'true'
       mylibs=cmo.getLibraries()
@@ -48,16 +61,28 @@ try:
       print 'deploying....'
       if versionidentifier:
         if planpath:
-          print 'deploying with version and deploymentplan....'
-          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote='true', upload='true',libraryModule=library,versionIdentifier=versionidentifier)
+        print 'deploying with version and deploymentplan....'
+        if stagingmode:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, stageMode=stagingmode, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
         else:
-          print 'deploying with version without deploymentplan....'
-          deploy(appName=name, path=localpath, targets=target, remote='true', upload='true',libraryModule=library,versionIdentifier=versionidentifier)
-      else: 
-        if planpath:
-          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote='true', upload='true',libraryModule=library)
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
+      else:
+        print 'deploying with version without deploymentplan....'
+        if stagingmode:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
         else:
-          deploy(appName=name, path=localpath, targets=target, remote='true', upload='true',libraryModule=library)
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library,versionIdentifier=versionidentifier)
+    else: 
+      if planpath:
+        if stagingmode:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library)
+        else:
+          deploy(appName=name, path=localpath, planPath=planpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library)
+      else:
+        if stagingmode:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, stageMode=stagingmode, upload=uploadflag,libraryModule=library)
+        else:
+          deploy(appName=name, path=localpath, targets=target, remote=remoteflag, upload=uploadflag,libraryModule=library)
     else:
       print 'change targets for app '+fullApp
 

--- a/lib/puppet/type/wls_deployment.rb
+++ b/lib/puppet/type/wls_deployment.rb
@@ -49,6 +49,9 @@ module Puppet
     property :targettype
     property :deploymenttype
     property :versionidentifier
+    property :remote
+    property :upload
+    property :stagingmode
 
     add_title_attributes(:deployment_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_deployment/remote.rb
+++ b/lib/puppet/type/wls_deployment/remote.rb
@@ -1,0 +1,14 @@
+newproperty(:remote) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  desc 'remote option for deployment.'
+  newvalues(1, 0)
+
+  defaultto '1'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['remote']
+  end
+
+end

--- a/lib/puppet/type/wls_deployment/stagingmode.rb
+++ b/lib/puppet/type/wls_deployment/stagingmode.rb
@@ -1,0 +1,10 @@
+newproperty(:stagingmode) do
+  include EasyType
+
+  desc 'The staging type'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['stagingmode']
+  end
+
+end

--- a/lib/puppet/type/wls_deployment/upload.rb
+++ b/lib/puppet/type/wls_deployment/upload.rb
@@ -1,0 +1,14 @@
+newproperty(:upload) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  desc 'Upload option for deployment.'
+  newvalues(1, 0)
+
+  defaultto '1'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['upload']
+  end
+
+end


### PR DESCRIPTION
Added property "stagingmode" to set stageMode in wls_deployment for
multi-node cluster.
Added more property for remote & upload options in deploy(). This was
done to set this option for different stageMode such as "nostage"

Parameters added:
stagingmode ->Valid values are stage, nostage, and external_stage
remote -> 0 or 1 (Defaults 1 (true))
upload -> 0 or 1 (Defaults 1 (true))

Ex.

    deployment_application_instances:
      'webapp':
        ensure:            'present'
        deploymenttype:    'AppDeployment'
        versionidentifier: '1.1@1.1.0.0'
        stagingmode:    "nostage"
        remote:         "1"
        upload:         "0"
        target:
          - 'AdminServer'
          - 'WebCluster'
        targettype:
          - 'Server'
          - 'Cluster'
        localpath:         '/vagrant/webapp.war'
