### PR TITLE
If you type lower case letters in the Schema User Name field, the Upgrade Assistant converts the name to upper case as per https://docs.oracle.com/middleware/1213/core/UAREF/ua_screens.htm#UAREF1050

### DIFF
--- a/files/wlst/checkrcu.py
+++ b/files/wlst/checkrcu.py
@@ -8,9 +8,8 @@ sysuser  = sys.argv[4]
 conn = DriverManager.getConnection(jdbcurl, sysuser + " as sysdba", password)
 stmt = conn.createStatement()
 try:
-    rs = stmt.executeQuery("select distinct 'found' from system.schema_version_registry where mrc_name ='"+prefix+"'")
+    rs = stmt.executeQuery("select distinct 'found' from system.schema_version_registry where upper(mrc_name) = upper('"+prefix+"')")
 
-    emp = {}
     while rs.next():
       print rs.getString(1)
 


### PR DESCRIPTION
My DBA likes to create DB prefix with same name as OSB or SOA Weblogic domains.
Oracle converts every DB prefix, aka Schema User Name, into UPPER case.
The fix is to use the function UPPER prior to the comparison in your SQL statement.