### PR TITLE
Add FTP Resource Adapter, multiple adapter_entry_property possible

### DIFF
--- a/lib/facter/orawls.rb
+++ b/lib/facter/orawls.rb
@@ -442,6 +442,7 @@ def get_domain(domain_path, n)
       else
         ftpAdapterPlan += apps.elements['plan-path'].text
       end
+      Puppet.debug "ftp #{ftpAdapterPlan}"
       if FileTest.exists?(ftpAdapterPlan)
 
         subfile = File.read(ftpAdapterPlan)

--- a/manifests/resourceadapter.pp
+++ b/manifests/resourceadapter.pp
@@ -125,8 +125,21 @@ define orawls::resourceadapter(
         content => template('orawls/adapter_plans/Plan_AQ.xml.erb'),
       }
     }
+  } elsif $adapter_name == 'FtpAdapter' {
+    if !defined(File["${adapter_plan_dir}/${adapter_plan}"]) {
+      file { "${adapter_plan_dir}/${adapter_plan}":
+        ensure  => present,
+        mode    => '0744',
+        replace => false,
+        owner   => $os_user,
+        group   => $os_group,
+        backup  => false,
+        path    => "${adapter_plan_dir}/${adapter_plan}",
+        content => template('orawls/adapter_plans/Plan_FTP.xml.erb'),
+      }
+    }
   } else {
-    fail("adapter_name ${adapter_name} is unknown, choose for DbAdapter,JmsAdapter or AqAdapter ")
+    fail("adapter_name ${adapter_name} is unknown, choose for DbAdapter, JmsAdapter, FtpAdapter or AqAdapter ")
   }
 
   # lets make the a new plan for this adapter
@@ -163,7 +176,7 @@ define orawls::resourceadapter(
   # after deployment of the plan we can add a new entry to the adapter
   if ( $continueEntry ) {
 
-    if $adapter_name == 'DbAdapter' or $adapter_name == 'AqAdapter'  {
+    if $adapter_name == 'DbAdapter' or $adapter_name == 'AqAdapter' or $adapter_name == 'FtpAdapter'  {
       $connectionFactoryInterface='javax.resource.cci.ConnectionFactory'
     } elsif $adapter_name == 'JmsAdapter' {
       $connectionFactoryInterface='oracle.tip.adapter.jms.IJmsConnectionFactory'

--- a/templates/adapter_plans/Plan_FTP.xml.erb
+++ b/templates/adapter_plans/Plan_FTP.xml.erb
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<deployment-plan xmlns="http://xmlns.oracle.com/weblogic/deployment-plan" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.oracle.com/weblogic/deployment-plan http://xmlns.oracle.com/weblogic/deployment-plan/1.0/deployment-plan.xsd" global-variables="false">
+  <application-name>FtpAdapter</application-name>
+  <variable-definition>
+    <variable>
+      <name>ConnectionInstance_eis/Ftp/initial_JNDIName_14302222837230</name>
+      <value>eis/Ftp/initial</value>
+    </variable>
+  </variable-definition>
+  <module-override>
+    <module-name>FtpAdapter.rar</module-name>
+    <module-type>rar</module-type>
+    <module-descriptor external="false">
+      <root-element>weblogic-connector</root-element>
+      <uri>META-INF/weblogic-ra.xml</uri>
+      <variable-assignment>
+        <name>ConnectionInstance_eis/Ftp/initial_JNDIName_14302222837230</name>
+        <xpath>/weblogic-connector/outbound-resource-adapter/connection-definition-group/[connection-factory-interface="javax.resource.cci.ConnectionFactory"]/connection-instance/[jndi-name="eis/Ftp/initial"]/jndi-name</xpath>
+        <origin>planbased</origin>
+      </variable-assignment>
+    </module-descriptor>
+    <module-descriptor external="false">
+      <root-element>connector</root-element>
+      <uri>META-INF/ra.xml</uri>
+    </module-descriptor>
+    <module-descriptor external="true">
+      <root-element>wldf-resource</root-element>
+      <uri>META-INF/weblogic-diagnostics.xml</uri>
+    </module-descriptor>
+  </module-override>
+  <config-root><%= @adapter_plan_dir %></config-root>
+</deployment-plan>

--- a/templates/adapter_plans/createResourceAdapterEntry.py.erb
+++ b/templates/adapter_plans/createResourceAdapterEntry.py.erb
@@ -1,4 +1,6 @@
 import random
+import sys
+import traceback
 
 wlsUser    = '<%= @weblogic_user %>'  
 password   = sys.argv[1] 
@@ -16,44 +18,53 @@ planPath                    = '<%= @adapter_plan_dir %>/<%= @adapter_plan %>'
 
 useStoreConfig = '<%= @useStoreConfig %>'
  
-moduleOverrideName=appName+'.rar'
+moduleOverrideName=appName + '.rar'
 moduleDescriptorName='META-INF/weblogic-ra.xml'
-idRandom=random.randint(10000,100000)
-connectionInstance='ConnectionInstance_eis/wls/MyCF_JNDIName_'+str(idRandom)
-configProperty='ConfigProperty_ConnectionFactoryLocation_Value_'+str(idRandom)
+connectionInstance='ConnectionInstance_' + eisName
 
 def makeDeploymentPlanVariable(wlstPlan, name, value, xpath, origin='planbased'):
  
-	while wlstPlan.getVariableAssignment(name, moduleOverrideName, moduleDescriptorName):
-		wlstPlan.destroyVariableAssignment(name, moduleOverrideName, moduleDescriptorName)
-	
-	while wlstPlan.getVariable(name):
-		wlstPlan.destroyVariable(name)
-	
-	variableAssignment = wlstPlan.createVariableAssignment( name, moduleOverrideName, moduleDescriptorName )
-	variableAssignment.setXpath( xpath )
-	variableAssignment.setOrigin( origin )
-	wlstPlan.createVariable( name, value )
- 
+    while wlstPlan.getVariableAssignment(name, moduleOverrideName, moduleDescriptorName):
+        wlstPlan.destroyVariableAssignment(name, moduleOverrideName, moduleDescriptorName)
+    
+    while wlstPlan.getVariable(name):
+        wlstPlan.destroyVariable(name)
+    
+    variableAssignment = wlstPlan.createVariableAssignment( name, moduleOverrideName, moduleDescriptorName )
+    variableAssignment.setXpath( xpath )
+    variableAssignment.setOrigin( origin )
+    wlstPlan.createVariable( name, value )
  
 def main():
-	
-	edit()
-	try:
-		startEdit()
-		
-		myPlan=loadApplication(appPath, planPath)
-		
-		print '___ BEGIN change plan'
-		makeDeploymentPlanVariable(myPlan, connectionInstance, eisName, '/weblogic-connector/outbound-resource-adapter/connection-definition-group/[connection-factory-interface="'+connectionFactoryInterface+'"]/connection-instance/[jndi-name="'+ eisName + '"]/jndi-name')
-		makeDeploymentPlanVariable(myPlan, configProperty, cfName, '/weblogic-connector/outbound-resource-adapter/connection-definition-group/[connection-factory-interface="'+connectionFactoryInterface+'"]/connection-instance/[jndi-name="'+ eisName + '"]/connection-properties/properties/property/[name="'+propertyName+'"]/value')
-		print '___ DONE change plan'
-		
-		myPlan.save();
-		save();
-		activate(block='true');
-	except:
-		stopEdit('y')
+    edit()
+    try:
+      startEdit()
+
+      myPlan=loadApplication(appPath, planPath)
+
+      print '___ BEGIN change plan'
+      makeDeploymentPlanVariable(myPlan, connectionInstance, eisName, '/weblogic-connector/outbound-resource-adapter/connection-definition-group/[connection-factory-interface="' + connectionFactoryInterface + '"]/connection-instance/[jndi-name="' + eisName + '"]/jndi-name')
+      myPlan.save();
+
+      pList = propertyName.split(';')
+      vList = cfName.split(';')
+      if len(pList) == len(vList):
+        i = 0
+        for p in pList:
+          configProperty='ConfigProperty_' + p + '_'+eisName
+          configPropertyValue=vList[i]
+          makeDeploymentPlanVariable(myPlan, configProperty, configPropertyValue, '/weblogic-connector/outbound-resource-adapter/connection-definition-group/[connection-factory-interface="' + connectionFactoryInterface + '"]/connection-instance/[jndi-name="' + eisName + '"]/connection-properties/properties/property/[name="' + p + '"]/value')
+          myPlan.save();
+          i += 1
+        print '___ DONE change plan'
+        save();
+        activate(block='true');
+      else:
+        print 'ERROR: The amount of properties and values are not correct.'
+        stopEdit('y')
+    except:
+      apply(traceback.print_exception, sys.exc_info())
+      stopEdit('y')
 
 if useStoreConfig != "true":
     connect(wlsUser,password,'t3://'+machine+':'+portNumber)


### PR DESCRIPTION
Added FTP adapter

Now it is possible to add more key/values in Adapter config, example:

adapter_entry_property:
'FtpAbsolutePathBegin;FtpPathSeparator;Host;ListParserKey;Password;ServerType;UseFtps;Username;UseSftp'
adapter_entry_value:
'/BDDC;/;l2-ibrfongen02.nl.rsg;UNIX;;unix;false;kim;false'