### PR TITLE
Removed default forwarddelay attribute value

### DIFF
--- a/lib/puppet/type/wls_jms_queue/forwarddelay.rb
+++ b/lib/puppet/type/wls_jms_queue/forwarddelay.rb
@@ -2,8 +2,6 @@ newproperty(:forwarddelay) do
   include EasyType
   include EasyType::Mungers::Integer
 
-  defaultto(-1)
-
   desc 'The number of seconds after which a uniform distributed queue member with no consumers will wait before forwarding its messages to other uniform distributed queue members that do have consumers. '
 
   to_translate_to_resource do | raw_resource|


### PR DESCRIPTION
I've removed the default attribute from the custom type. This way the original code works, unless the forwarddelay attribute is set. The other way would be to change the generated WLST code to check the distributed flag. But I suspect the default WLS setting is -1 for a distributed queue anyway.