### PR TITLE
BugFix: secondstotrustidlepoolconnection of type Wls_datasource is not idempotent

### DIFF
--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -38,9 +38,9 @@ for token in m:
            statementcachesize 	= '10'
         testconnectionsonreserve = str(get('TestConnectionsOnReserve'))
         
-        secondstotrustidlepoolconnection = get('SecondsToTrustAnIdlePoolConnection')
+        secondstotrustidlepoolconnection = str(get('SecondsToTrustAnIdlePoolConnection'))
         testfrequency = get('TestFrequencySeconds')
-        connectioncreationretryfrequency = get('ConnectionCreationRetryFrequencySeconds')
+        connectioncreationretryfrequency = str(get('ConnectionCreationRetryFrequencySeconds'))
 
         cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDataSourceParams/' + token )
         jndinames = get('JNDINames')


### PR DESCRIPTION
When the attributes SecondsToTrustAnIdlePoolConnection and Connection…CreationRetryFrequencySeconds contain the value '0' then nill is used instead of '0'