### PR TITLE
Add support for managing JDBC persistence stores in Weblogic domain

### DIFF
--- a/files/providers/wls_jdbc_persistence_store/create.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/create.py.erb
@@ -1,0 +1,32 @@
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+
+name           = '<%= jdbc_persistence_name %>'
+datasource     = '<%= datasource %>'
+prefix_name    = '<%= prefix_name %>'
+target         = '<%= target %>'
+targettype     = '<%= targettype %>'
+
+edit()
+startEdit()
+
+try:
+    cd('/')
+    cmo.createJDBCStore(name)
+    cd('/JDBCStores/'+name)
+    cmo.setDataSource(getMBean('/SystemResources/'+datasource))
+    cmo.setPrefixName(prefix_name)
+    set('Targets', jarray.array([ObjectName('com.bea:Name='+target+',Type='+targettype)], ObjectName))
+
+    save()
+    activate()
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    undo('true','y')
+    stopEdit('y')
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/files/providers/wls_jdbc_persistence_store/destroy.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/destroy.py.erb
@@ -1,0 +1,23 @@
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+
+name           = '<%= jdbc_persistence_name %>'
+
+edit()
+startEdit()
+
+try:
+    cd('/JDBCStores')
+    cmo.destroyJDBCStore(getMBean('/JDBCStores/'+name))
+    save()
+    activate()
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    undo('true','y')
+    stopEdit('y')
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/files/providers/wls_jdbc_persistence_store/index.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/index.py.erb
@@ -1,0 +1,32 @@
+
+
+def quote(text):
+    if text:
+        return "\"" + str(text).replace("\"", "\"\"") + "\""
+    else:
+        return ""
+
+m = ls('/JDBCStores',returnMap='true')
+
+f = open("/tmp/wlstScript.out", "w")
+print >>f, "name;datasource;prefix_name;target;targettype;domain"
+for token in m:
+    print '___'+token+'___'
+    cd('/JDBCStores/'+token)
+
+    datasourceObject = get('DataSource')
+    datasource = datasourceObject.getKeyProperty('Name')
+
+    prefix_name = get('PrefixName')
+
+    n = ls('/JDBCStores/'+token+'/Targets',returnMap='true')
+    target     = []
+    targetType = []
+    for token2 in n:
+           target.append(token2)
+           cd('/JDBCStores/'+token+'/Targets/'+token2)
+           targetType.append(get('Type'))
+
+    print >>f, ";".join(map(quote, [domain+'/'+token,datasource,prefix_name,','.join(target),','.join(targetType),domain]))
+f.close()
+print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_jdbc_persistence_store/modify.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/modify.py.erb
@@ -1,0 +1,31 @@
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+
+name           = '<%= jdbc_persistence_name %>'
+datasource     = '<%= datasource %>'
+prefix_name    = '<%= prefix_name %>'
+target         = '<%= target %>'
+targettype     = '<%= targettype %>'
+
+edit()
+startEdit()
+
+try:
+    cd('/')
+    cd('/JDBCStores/'+name)
+    cmo.setDataSource(getMBean('/SystemResources/'+datasource))
+    cmo.setPrefixName(prefix_name)
+    set('Targets', jarray.array([ObjectName('com.bea:Name='+target+',Type='+targettype)], ObjectName))
+
+    save()
+    activate()
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    undo('true','y')
+    stopEdit('y')
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/lib/puppet/provider/wls_jdbc_persistence_store/simple.rb
+++ b/lib/puppet/provider/wls_jdbc_persistence_store/simple.rb
@@ -1,0 +1,9 @@
+require 'easy_type'
+require 'utils/wls_access'
+
+Puppet::Type.type(:wls_jdbc_persistence_store).provide(:simple) do
+  include EasyType::Provider
+
+  desc 'Manage JDBC persistence stores'
+  mk_resource_methods
+end

--- a/lib/puppet/type/wls_jdbc_persistence_store.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store.rb
@@ -1,0 +1,55 @@
+require 'easy_type'
+require 'utils/wls_access'
+require 'utils/settings'
+require 'utils/title_parser'
+require 'facter'
+
+module Puppet
+  #
+  newtype(:wls_jdbc_persistence_store) do
+    include EasyType
+    include Utils::WlsAccess
+    extend Utils::TitleParser
+
+    desc 'This resource allows you to manage a JDBC persistence stores in an WebLogic domain.'
+
+    ensurable
+
+    set_command(:wlst)
+
+    to_get_raw_resources do
+      Puppet.info "index #{name}"
+      environment = { 'action' => 'index', 'type' => 'wls_jdbc_persistence_store' }
+      wlst template('puppet:///modules/orawls/providers/wls_jdbc_persistence_store/index.py.erb', binding), environment
+    end
+
+    on_create  do | command_builder |
+      Puppet.info "create #{name} "
+      template('puppet:///modules/orawls/providers/wls_jdbc_persistence_store/create.py.erb', binding)
+    end
+
+    on_modify  do | command_builder |
+      Puppet.info "modify #{name} "
+      template('puppet:///modules/orawls/providers/wls_jdbc_persistence_store/modify.py.erb', binding)
+    end
+
+    on_destroy  do | command_builder |
+      Puppet.info "destroy #{name} "
+      template('puppet:///modules/orawls/providers/wls_jdbc_persistence_store/destroy.py.erb', binding)
+    end
+
+    parameter :domain
+    parameter :name
+    parameter :jdbc_persistence_name
+    parameter :timeout
+    property :datasource
+    property :prefix_name
+    property :target
+    property :targettype
+
+    add_title_attributes(:jdbc_persistence_name) do
+      /^((.*\/)?(.*)?)$/
+    end
+
+  end
+end

--- a/lib/puppet/type/wls_jdbc_persistence_store/datasource.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store/datasource.rb
@@ -1,0 +1,12 @@
+newproperty(:datasource) do
+  include EasyType
+
+  desc 'The JDBC persistent store datasource'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['datasource']
+  end
+
+end
+
+autorequire(:wls_datasource) { datasource }

--- a/lib/puppet/type/wls_jdbc_persistence_store/jdbc_persistence_name.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store/jdbc_persistence_name.rb
@@ -1,0 +1,9 @@
+newparam(:jdbc_persistence_name) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  isnamevar
+
+  desc 'The JDBC persistence name'
+
+end

--- a/lib/puppet/type/wls_jdbc_persistence_store/prefix_name.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store/prefix_name.rb
@@ -1,0 +1,10 @@
+newproperty(:prefix_name) do
+  include EasyType
+
+  desc 'The JDBC persistent store prefix name'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['prefix_name']
+  end
+
+end


### PR DESCRIPTION
Hi Edwin,

I've added a custom type/provider for managing JDBC persistence stores. I've tested create/modify/delete on a Weblogic 10.3.6 instance on CentOS 6.4.

Bryan