### PR TITLE
BugFix: forwarddelay of type wls_jms_queue is not idempotent

### DIFF
--- a/files/providers/wls_jms_queue/index.py.erb
+++ b/files/providers/wls_jms_queue/index.py.erb
@@ -12,7 +12,7 @@ def queue(token,token2,location,distributed):
 
     forwardDelay = ''
     try:
-      forwardDelay = get('ForwardDelay')
+      forwardDelay = str(get('ForwardDelay'))
     except:
       print "forwardDelay failed, probably a normal queue"
 
@@ -21,7 +21,6 @@ def queue(token,token2,location,distributed):
        subdeployment = ''
     else:
        subdeployment = cmo.getSubDeploymentName()
-
 
     if distributed == '1':
       balancingPolicy  = get('LoadBalancingPolicy')


### PR DESCRIPTION
When the attribute ForwardDelay contains the value '0' then nill is used instead of '0'