### PR TITLE
Fix wls_deployment updates when version is none.

### DIFF
--- a/files/providers/wls_deployment/modify.py.erb
+++ b/files/providers/wls_deployment/modify.py.erb
@@ -53,7 +53,7 @@ try:
     # if we got the right app
     print 'step 1....'
     cd('/')
-    print 'current version: '+ currentVersionidentifier
+    print 'current version: '+str(currentVersionidentifier)
     # version is different
     if currentVersionidentifier != versionidentifier:
       print 'undeploy....'


### PR DESCRIPTION
This resoles the following error message When VersionIdentifier is null:

TypeError: cannot concatenate 'str' and 'NoneType' objects