### PR TITLE
Fixes issue where weblogic_home_dir is ignored during WebLogic install

### DIFF
--- a/manifests/bsu.pp
+++ b/manifests/bsu.pp
@@ -72,7 +72,7 @@ define orawls::bsu (
     }
 
     exec { "patch policy for ${patch_file}":
-      command   => "bash -c \"{ echo 'grant codeBase \\\"file:${middleware_home_dir}/patch_wls1036/patch_jars/-\\\" {'; echo '      permission java.security.AllPermission;'; echo '};'; } >> ${middleware_home_dir}/wlserver_10.3/server/lib/weblogic.policy\"",
+      command   => "bash -c \"{ echo 'grant codeBase \\\"file:${middleware_home_dir}/patch_wls1036/patch_jars/-\\\" {'; echo '      permission java.security.AllPermission;'; echo '};'; } >> ${weblogic_home_dir}/server/lib/weblogic.policy\"",
       unless    => "grep 'file:${middleware_home_dir}/patch_wls1036/patch_jars/-' ${weblogic_home_dir}/server/lib/weblogic.policy",
       path      => $exec_path,
       user      => $os_user,

--- a/templates/weblogic_silent_install.xml.erb
+++ b/templates/weblogic_silent_install.xml.erb
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-   <bea-installer> 
+   <bea-installer>
      <input-fields>
        <data-value name="BEAHOME" value="<%= @middleware_home_dir %>" />
-   </input-fields> 
+       <data-value name="WLS_INSTALL_DIR" value="<%= @weblogic_home_dir %>" />
+   </input-fields>
 </bea-installer>


### PR DESCRIPTION
The path for WebLogic's home was hard coded in bsu.pp to where Oracle installs it by default. Also had to add the `WLS_INSTALL_DIR` setting in the silent install file so that WebLogic would know to install in a non-default location. I did this per http://docs.oracle.com/cd/E23943_01/doc.1111/e14142/silent.htm#WLSIG134