### PR TITLE
Add Truststore specification in nodemanager properties

### DIFF
--- a/templates/nodemgr/nodemanager.properties_1213.erb
+++ b/templates/nodemgr/nodemanager.properties_1213.erb
@@ -29,4 +29,5 @@ CustomIdentityKeyStoreFileName=<%= @custom_identity_keystore_filename %>
 CustomIdentityKeyStorePassPhrase=<%= @custom_identity_keystore_passphrase %>
 CustomIdentityAlias=<%= @custom_identity_alias %>
 CustomIdentityPrivateKeyPassPhrase=<%= @custom_identity_privatekey_passphrase %>
+CustomTrustKeyStoreFileName=<%= @trust_keystore_file %>
 <% end %>


### PR DESCRIPTION
This PR add the option to add a custom trust keystore file for nodemanager. Only tested for 12.1.3