### PR TITLE
Add domain options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1026,6 +1026,10 @@ When using ssh (use_ssh = true) you need to setup ssh so you won't need to provi
       adminserver_port       => 7001,
       weblogic_user          => "weblogic",
       weblogic_password      => "weblogic1",
+      setinternalappdeploymentondemandenable => false,
+      setconfigbackupenabled                 => true,
+      setarchiveconfigurationcount           => 10,
+      setconfigurationaudittype              => 'logaudit',
     }
 
 Configuration with Hiera ( need to have puppet > 3.0 )

--- a/files/providers/wls_domain/index.py.erb
+++ b/files/providers/wls_domain/index.py.erb
@@ -7,10 +7,15 @@ def quote(text):
         return ""
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;domain;jta_transaction_timeout;jta_max_transactions;jpa_default_provider;security_crossdomain;log_file_min_size;log_filecount;log_rotate_logon_startup;log_filename;log_rotationtype;log_number_of_files_limited;jmx_platform_mbean_server_enabled;jmx_platform_mbean_server_used;web_app_container_show_archived_real_path_enabled"
+print >>f, "name;domain;jta_transaction_timeout;jta_max_transactions;jpa_default_provider;security_crossdomain;log_file_min_size;log_filecount;log_rotate_logon_startup;log_filename;log_rotationtype;log_number_of_files_limited;jmx_platform_mbean_server_enabled;jmx_platform_mbean_server_used;web_app_container_show_archived_real_path_enabled;setinternalappdeploymentondemandenable;setarchiveconfigurationcount;setconfigbackupenabled;setconfigurationaudittype"
 
 cd('/')
 domain_name = get('Name')
+
+setinternalappdeploymentondemandenable = str(get('InternalAppsDeployOnDemandEnabled'))
+setarchiveconfigurationcount = cmo.getArchiveConfigurationCount()
+setconfigbackupenabled = get('ConfigBackupEnabled')
+setconfigurationaudittype = cmo.getConfigurationAuditType()
 
 cd('/Log/'+domain_name)
 log_rotationtype            = get('RotationType')
@@ -41,7 +46,7 @@ jmx_platform_mbean_server_used = str(get('PlatformMBeanServerUsed'))
 cd('/WebAppContainer/'+domain_name)
 web_app_container_show_archived_real_path_enabled = str(get('ShowArchivedRealPathEnabled'))
 
-print >>f, ";".join(map(quote, [domain+'/'+domain_name,domain,jta_transaction_timeout,jta_max_transactions,jpa_default_provider,security_crossdomain,log_file_min_size,log_filecount,log_rotate_logon_startup,log_filename,log_rotationtype,log_number_of_files_limited,jmx_platform_mbean_server_enabled,jmx_platform_mbean_server_used,web_app_container_show_archived_real_path_enabled]))
+print >>f, ";".join(map(quote, [domain+'/'+domain_name,domain,jta_transaction_timeout,jta_max_transactions,jpa_default_provider,security_crossdomain,log_file_min_size,log_filecount,log_rotate_logon_startup,log_filename,log_rotationtype,log_number_of_files_limited,jmx_platform_mbean_server_enabled,jmx_platform_mbean_server_used,web_app_container_show_archived_real_path_enabled,setinternalappdeploymentondemandenable,setarchiveconfigurationcount,setconfigbackupenabled,setconfigurationaudittype]))
 
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_domain/modify.py.erb
+++ b/files/providers/wls_domain/modify.py.erb
@@ -19,6 +19,11 @@ log_rotate_logon_startup                           = '<%= log_rotate_logon_start
 log_rotationtype                                   = '<%= log_rotationtype %>'
 log_number_of_files_limited                        = '<%= log_number_of_files_limited %>'
 
+setinternalappdeploymentondemandenable             = '<%= setinternalappdeploymentondemandenable %>'
+setarchiveconfigurationcount                       = '<%= setarchiveconfigurationcount %>'
+setconfigbackupenabled                             = '<%= setconfigbackupenabled %>'
+setconfigurationaudittype                          = '<%= setconfigurationaudittype %>'
+
 def formatBoolean(value):
   if value == '1':
     return true
@@ -81,6 +86,18 @@ try:
     cd('/WebAppContainer/'+name)
     if web_app_container_show_archived_real_path_enabled:
       cmo.setShowArchivedRealPathEnabled(formatBoolean(web_app_container_show_archived_real_path_enabled))
+
+
+    cd('/')
+    
+    print "Change Internal App deployment flag"
+    cmo.setInternalAppsDeployOnDemandEnabled(formatBoolean(setinternalappdeploymentondemandenable))
+ 
+    print "Change configuration backup settings"
+    cmo.setArchiveConfigurationCount(int(setarchiveconfigurationcount))
+    cmo.setConfigBackupEnabled(formatBoolean(setconfigbackupenabled))
+    
+    cmo.setConfigurationAuditType(setconfigurationaudittype)
 
     print "save"
     save()

--- a/lib/puppet/type/wls_domain.rb
+++ b/lib/puppet/type/wls_domain.rb
@@ -53,6 +53,10 @@ module Puppet
     property :jmx_platform_mbean_server_enabled
     property :jmx_platform_mbean_server_used
     property :web_app_container_show_archived_real_path_enabled
+    property :setinternalappdeploymentondemandenable
+    property :setconfigurationaudittype
+    property :setconfigbackupenabled
+    property :setarchiveconfigurationcount
 
     add_title_attributes(:weblogic_domain_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_domain/setarchiveconfigurationcount.rb
+++ b/lib/puppet/type/wls_domain/setarchiveconfigurationcount.rb
@@ -1,0 +1,10 @@
+newproperty(:setarchiveconfigurationcount) do
+  include EasyType
+
+  desc 'The amount of archived backups of the domain configuration file retained'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['setarchiveconfigurationcount']
+  end
+
+end

--- a/lib/puppet/type/wls_domain/setconfigbackupenabled.rb
+++ b/lib/puppet/type/wls_domain/setconfigbackupenabled.rb
@@ -1,0 +1,10 @@
+newproperty(:setconfigbackupenabled) do
+  include EasyType
+
+  desc 'Enable or disable configuration backup for the domain'
+  
+  to_translate_to_resource do | raw_resource|
+    raw_resource['setconfigbackupenabled']
+  end
+
+end

--- a/lib/puppet/type/wls_domain/setconfigurationaudittype.rb
+++ b/lib/puppet/type/wls_domain/setconfigurationaudittype.rb
@@ -1,0 +1,11 @@
+newproperty(:setconfigurationaudittype) do
+  include EasyType
+
+  desc 'The configuration audit type'
+  defaultto 'None'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['setconfigurationaudittype']
+  end
+
+end

--- a/lib/puppet/type/wls_domain/setinternalappdeploymentondemandenable.rb
+++ b/lib/puppet/type/wls_domain/setinternalappdeploymentondemandenable.rb
@@ -1,0 +1,10 @@
+newproperty(:setinternalappdeploymentondemandenable) do
+  include EasyType
+  
+  desc 'Enable or disabled internal app deployment'
+  
+  to_translate_to_resource do | raw_resource|
+    raw_resource['setinternalappdeploymentondemandenable']
+  end
+
+end


### PR DESCRIPTION
This adds the following options to the domain type:

1. Configuration backup / archiving flag switching
2. specifying how many backups you want to keep of the configuration archive
3. Flag switching for the internal application deployment option
4. Configuration audit manipulation.