### PR TITLE
Fix setting loadbalancing enable

### DIFF
--- a/files/providers/wls_jms_connection_factory/create.py.erb
+++ b/files/providers/wls_jms_connection_factory/create.py.erb
@@ -67,7 +67,7 @@ try:
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/LoadBalancingParams/'+name)
     if loadbalancingenabled:
-      cmo.setServerAffinityEnabled( formatBoolean(loadbalancingenabled) )
+      cmo.setLoadBalancingEnabled( formatBoolean(loadbalancingenabled) )
     if serveraffinityenabled:
       cmo.setServerAffinityEnabled( formatBoolean(serveraffinityenabled) )
 

--- a/files/providers/wls_jms_connection_factory/modify.py.erb
+++ b/files/providers/wls_jms_connection_factory/modify.py.erb
@@ -64,7 +64,7 @@ try:
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/LoadBalancingParams/'+name)
     if loadbalancingenabled:
-      cmo.setServerAffinityEnabled( formatBoolean(loadbalancingenabled) )
+      cmo.setLoadBalancingEnabled( formatBoolean(loadbalancingenabled) )
     if serveraffinityenabled:
       cmo.setServerAffinityEnabled( formatBoolean(serveraffinityenabled) )
 


### PR DESCRIPTION
It used to set the `serveraffinity` based on the property `loadbalancingenabled`. This commit fixes this.