### PR TITLE
Fix "undefined method `sort' for :absent:Symbol"

### DIFF
--- a/lib/puppet/type/shared/target.rb
+++ b/lib/puppet/type/shared/target.rb
@@ -10,6 +10,7 @@ newproperty(:target, :array_matching => :all) do
   end
 
   def insync?(is)
+    is = [] if is == :absent or is.nil?
     is.sort == should.sort
   end
 


### PR DESCRIPTION
This was a problem when managing datasources that had become
untargetted.
Fixes https://github.com/biemond/biemond-orawls/issues/212

Fix as suggested by Bert Hajee https://github.com/hajee