### PR TITLE
Change defaulttargetting behavior for jms components

### DIFF
--- a/files/providers/wls_foreign_server/create.py.erb
+++ b/files/providers/wls_foreign_server/create.py.erb
@@ -31,9 +31,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if connectionurl:
       cmo.setConnectionURL(connectionurl)

--- a/files/providers/wls_foreign_server/create.py.erb
+++ b/files/providers/wls_foreign_server/create.py.erb
@@ -26,8 +26,14 @@ try:
     if defaulttargeting  == '1':
       cmo.setDefaultTargetingEnabled(true)
 
-    if subdeployment:
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
+    elif not subdeployment and defaulttargeting == "1":
+      cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if connectionurl:
       cmo.setConnectionURL(connectionurl)
@@ -58,6 +64,3 @@ except:
     undo('true','y')
     stopEdit('y')
     raise
-
-
-

--- a/files/providers/wls_foreign_server/modify.py.erb
+++ b/files/providers/wls_foreign_server/modify.py.erb
@@ -23,8 +23,14 @@ try:
     if defaulttargeting  == '1':
       cmo.setDefaultTargetingEnabled(true)
 
-    if subdeployment:
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
+    elif not subdeployment and defaulttargeting == "1":
+      cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if connectionurl:
       cmo.setConnectionURL(connectionurl)
@@ -59,6 +65,3 @@ except:
     undo('true','y')
     stopEdit('y')
     raise
-
-
-

--- a/files/providers/wls_foreign_server/modify.py.erb
+++ b/files/providers/wls_foreign_server/modify.py.erb
@@ -28,9 +28,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if connectionurl:
       cmo.setConnectionURL(connectionurl)

--- a/files/providers/wls_jms_connection_factory/create.py.erb
+++ b/files/providers/wls_jms_connection_factory/create.py.erb
@@ -42,8 +42,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/TransactionParams/'+name)
     if xaenabled == '1':

--- a/files/providers/wls_jms_connection_factory/create.py.erb
+++ b/files/providers/wls_jms_connection_factory/create.py.erb
@@ -40,8 +40,7 @@ try:
     cmo.setJNDIName(jndiname)
     cmo.setLocalJNDIName(localjndiname)
 
-    if subdeployment:
-      cmo.setDefaultTargetingEnabled(false)
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
     else:
       cmo.setDefaultTargetingEnabled(true)
@@ -91,4 +90,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-

--- a/files/providers/wls_jms_connection_factory/create.py.erb
+++ b/files/providers/wls_jms_connection_factory/create.py.erb
@@ -45,9 +45,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/TransactionParams/'+name)
     if xaenabled == '1':

--- a/files/providers/wls_jms_connection_factory/modify.py.erb
+++ b/files/providers/wls_jms_connection_factory/modify.py.erb
@@ -37,8 +37,7 @@ try:
     cmo.setJNDIName(jndiname)
     cmo.setLocalJNDIName(localjndiname)
 
-    if subdeployment:
-      cmo.setDefaultTargetingEnabled(false)
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
     else:
       cmo.setDefaultTargetingEnabled(true)
@@ -88,4 +87,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-

--- a/files/providers/wls_jms_connection_factory/modify.py.erb
+++ b/files/providers/wls_jms_connection_factory/modify.py.erb
@@ -39,8 +39,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/TransactionParams/'+name)
     if xaenabled == '1':

--- a/files/providers/wls_jms_connection_factory/modify.py.erb
+++ b/files/providers/wls_jms_connection_factory/modify.py.erb
@@ -42,9 +42,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/ConnectionFactories/'+name+'/TransactionParams/'+name)
     if xaenabled == '1':

--- a/files/providers/wls_jms_queue/create.py.erb
+++ b/files/providers/wls_jms_queue/create.py.erb
@@ -45,8 +45,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if forwarddelay:
       print "ForwardDelay"

--- a/files/providers/wls_jms_queue/create.py.erb
+++ b/files/providers/wls_jms_queue/create.py.erb
@@ -43,8 +43,10 @@ try:
     if templatename:
       set('Template',getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/Templates/'+templatename))
 
-    if subdeployment:
-      set('SubDeploymentName',subdeployment)
+    if subdeployment and defaulttargeting == "0":
+      cmo.setSubDeploymentName(subdeployment)
+    else:
+      cmo.setDefaultTargetingEnabled(true)
 
     if forwarddelay:
       print "ForwardDelay"
@@ -113,4 +115,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-

--- a/files/providers/wls_jms_queue/create.py.erb
+++ b/files/providers/wls_jms_queue/create.py.erb
@@ -48,9 +48,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if forwarddelay:
       print "ForwardDelay"

--- a/files/providers/wls_jms_queue/modify.py.erb
+++ b/files/providers/wls_jms_queue/modify.py.erb
@@ -43,9 +43,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if templatename:
       set('Template',getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/Templates/'+templatename))

--- a/files/providers/wls_jms_queue/modify.py.erb
+++ b/files/providers/wls_jms_queue/modify.py.erb
@@ -40,8 +40,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     if templatename:
       set('Template',getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/Templates/'+templatename))

--- a/files/providers/wls_jms_queue/modify.py.erb
+++ b/files/providers/wls_jms_queue/modify.py.erb
@@ -38,8 +38,10 @@ try:
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name)
     set('JNDIName',jndiname)
 
-    if subdeployment:
-      set('SubDeploymentName',subdeployment)
+    if subdeployment and defaulttargeting == "0":
+      cmo.setSubDeploymentName(subdeployment)
+    else:
+      cmo.setDefaultTargetingEnabled(true)
 
     if templatename:
       set('Template',getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/Templates/'+templatename))
@@ -111,4 +113,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-

--- a/files/providers/wls_jms_topic/create.py.erb
+++ b/files/providers/wls_jms_topic/create.py.erb
@@ -41,8 +41,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     print "distributed: ",distributed
     if distributed == "true":

--- a/files/providers/wls_jms_topic/create.py.erb
+++ b/files/providers/wls_jms_topic/create.py.erb
@@ -28,19 +28,21 @@ try:
 
     cd('/')
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule)
-     
+
     if distributed == "1":
         cmo.createUniformDistributedTopic(name)
         jmsWlsType = '/UniformDistributedTopics/'
     else:
         cmo.createTopic(name)
         jmsWlsType = '/Topics/'
-     
-    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name)
-    set('JNDIName',jndiname) 
 
-    if subdeployment:
-      set('SubDeploymentName',subdeployment)
+    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name)
+    set('JNDIName',jndiname)
+
+    if subdeployment and defaulttargeting == "0":
+      cmo.setSubDeploymentName(subdeployment)
+    else:
+      cmo.setDefaultTargetingEnabled(true)
 
     print "distributed: ",distributed
     if distributed == "true":
@@ -53,7 +55,7 @@ try:
 
     if redeliverylimit:
       print "limit"
-      cmo.setRedeliveryLimit( int(redeliverylimit) )  
+      cmo.setRedeliveryLimit( int(redeliverylimit) )
 
     print "before"
     if errordestinationtype:
@@ -65,8 +67,8 @@ try:
         jmsErrType = 'Queues'
 
     print "after"
- 
-    print "errorbean "+'/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination 
+
+    print "errorbean "+'/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination
     if errordestination:
         cmo.setErrorDestination(getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination))
 
@@ -77,15 +79,15 @@ try:
       print "time To Live"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       #TimeToLive is an int MBean attribute
-      cmo.setTimeToLive( int(timetolive))   
+      cmo.setTimeToLive( int(timetolive))
 
     if timetodeliver:
       print "time To Deliver"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       #TimeToDeliver is a string MBean attribute
-      cmo.setTimeToDeliver(timetodeliver)                             
+      cmo.setTimeToDeliver(timetodeliver)
 
-    if redeliverydelay: 
+    if redeliverydelay:
       print "RedeliveryDelay"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       cmo.setRedeliveryDelay( int(redeliverydelay))
@@ -105,7 +107,7 @@ try:
       cmo.setMessageLoggingEnabled(false)
 
     save()
-    activate()          
+    activate()
     print "~~~~COMMAND SUCCESFULL~~~~"
 
 except:
@@ -114,6 +116,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-
-
-

--- a/files/providers/wls_jms_topic/create.py.erb
+++ b/files/providers/wls_jms_topic/create.py.erb
@@ -44,9 +44,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     print "distributed: ",distributed
     if distributed == "true":

--- a/files/providers/wls_jms_topic/modify.py.erb
+++ b/files/providers/wls_jms_topic/modify.py.erb
@@ -29,17 +29,19 @@ try:
 
     cd('/')
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule)
-     
+
     if distributed == "1":
         jmsWlsType = '/UniformDistributedTopics/'
     else:
         jmsWlsType = '/Topics/'
-     
-    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name)
-    set('JNDIName',jndiname) 
 
-    if subdeployment:
-      set('SubDeploymentName',subdeployment)
+    cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name)
+    set('JNDIName',jndiname)
+
+    if subdeployment and defaulttargeting == "0":
+      cmo.setSubDeploymentName(subdeployment)
+    else:
+      cmo.setDefaultTargetingEnabled(true)
 
     print "distributed: ",distributed
     if distributed == "true":
@@ -52,7 +54,7 @@ try:
 
     if redeliverylimit:
       print "limit"
-      cmo.setRedeliveryLimit( int(redeliverylimit) )  
+      cmo.setRedeliveryLimit( int(redeliverylimit) )
 
     print "before"
     if errordestinationtype:
@@ -64,8 +66,8 @@ try:
         jmsErrType = 'Queues'
 
     print "after"
- 
-    print "errorbean "+'/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination 
+
+    print "errorbean "+'/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination
     if errordestination:
       cmo.setErrorDestination(getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/'+jmsErrType+'/'+errordestination))
 
@@ -76,15 +78,15 @@ try:
       print "time To Live"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       #TimeToLive is an int MBean attribute
-      cmo.setTimeToLive( int(timetolive))   
+      cmo.setTimeToLive( int(timetolive))
 
     if timetodeliver:
       print "time To Deliver"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       #TimeToDeliver is a string MBean attribute
-      cmo.setTimeToDeliver(timetodeliver)                             
+      cmo.setTimeToDeliver(timetodeliver)
 
-    if redeliverydelay: 
+    if redeliverydelay:
       print "RedeliveryDelay"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/DeliveryParamsOverrides/'+name)
       cmo.setRedeliveryDelay( int(redeliverydelay))
@@ -102,9 +104,9 @@ try:
       print "message logging"
       cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+jmsWlsType+name+'/MessageLoggingParams/'+name)
       cmo.setMessageLoggingEnabled(false)
-      
+
     save()
-    activate()          
+    activate()
     print "~~~~COMMAND SUCCESFULL~~~~"
 
 except:
@@ -113,6 +115,3 @@ except:
     stopEdit('y')
     print "~~~~COMMAND FAILED~~~~"
     raise
-
-
-

--- a/files/providers/wls_jms_topic/modify.py.erb
+++ b/files/providers/wls_jms_topic/modify.py.erb
@@ -43,9 +43,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     print "distributed: ",distributed
     if distributed == "true":

--- a/files/providers/wls_jms_topic/modify.py.erb
+++ b/files/providers/wls_jms_topic/modify.py.erb
@@ -40,8 +40,12 @@ try:
 
     if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
-    else:
+    elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     print "distributed: ",distributed
     if distributed == "true":

--- a/files/providers/wls_saf_imported_destination/create.py.erb
+++ b/files/providers/wls_saf_imported_destination/create.py.erb
@@ -51,9 +51,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     save()
     activate()

--- a/files/providers/wls_saf_imported_destination/create.py.erb
+++ b/files/providers/wls_saf_imported_destination/create.py.erb
@@ -22,7 +22,7 @@ try:
 
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule)
     cmo.createSAFImportedDestinations(name)
-    
+
     cd('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/SAFImportedDestinations/'+name)
     cmo.setSAFRemoteContext(getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/SAFRemoteContexts/'+remotecontext))
 
@@ -31,26 +31,32 @@ try:
     if errorhandling:
       cmo.setSAFErrorHandling(getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/SAFErrorHandlings/'+errorhandling))
     else:
-      cmo.setSAFErrorHandling(None)  
+      cmo.setSAFErrorHandling(None)
 
     if timetolivedefault:
       cmo.setTimeToLiveDefault(long(timetolivedefault))
     else:
-      cmo.setTimeToLiveDefault(0)  
+      cmo.setTimeToLiveDefault(0)
 
     if usetimetolivedefault == '1':
       cmo.setUseSAFTimeToLiveDefault(true)
     else:
-      cmo.setUseSAFTimeToLiveDefault(false)   
-    
+      cmo.setUseSAFTimeToLiveDefault(false)
+
     if defaulttargeting  == '1':
       cmo.setDefaultTargetingEnabled(true)
 
-    if subdeployment:
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
+    elif not subdeployment and defaulttargeting == "1":
+      cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     save()
-    activate()          
+    activate()
     print "~~~~COMMAND SUCCESFULL~~~~"
 
 except:
@@ -60,6 +66,3 @@ except:
     undo('true','y')
     stopEdit('y')
     raise
-
-
-

--- a/files/providers/wls_saf_imported_destination/modify.py.erb
+++ b/files/providers/wls_saf_imported_destination/modify.py.erb
@@ -48,9 +48,9 @@ try:
     elif not subdeployment and defaulttargeting == "1":
       cmo.setDefaultTargetingEnabled(true)
     elif subdeployment and defaulttargeting == "1":
-      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+      raise ValueError('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
     else:
-      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
+      raise ValueError('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     save()
     activate()

--- a/files/providers/wls_saf_imported_destination/modify.py.erb
+++ b/files/providers/wls_saf_imported_destination/modify.py.erb
@@ -28,26 +28,32 @@ try:
     if errorhandling:
       cmo.setSAFErrorHandling(getMBean('/JMSSystemResources/'+jmsmodule+'/JMSResource/'+jmsmodule+'/SAFErrorHandlings/'+errorhandling))
     else:
-      cmo.setSAFErrorHandling(None)  
+      cmo.setSAFErrorHandling(None)
 
     if timetolivedefault:
       cmo.setTimeToLiveDefault(long(timetolivedefault))
     else:
-      cmo.setTimeToLiveDefault(0)  
+      cmo.setTimeToLiveDefault(0)
 
     if usetimetolivedefault == '1':
       cmo.setUseSAFTimeToLiveDefault(true)
     else:
-      cmo.setUseSAFTimeToLiveDefault(false)   
-    
+      cmo.setUseSAFTimeToLiveDefault(false)
+
     if defaulttargeting  == '1':
       cmo.setDefaultTargetingEnabled(true)
 
-    if subdeployment:
+    if subdeployment and defaulttargeting == "0":
       cmo.setSubDeploymentName(subdeployment)
+    elif not subdeployment and defaulttargeting == "1":
+      cmo.setDefaultTargetingEnabled(true)
+    elif subdeployment and defaulttargeting == "1":
+      raise Exception('Defaulttargeting and Subdeployment are both set, only one can be active for JMS components')
+    else:
+      raise Exception('Either defaulttargeting or a subdeployment needs to be selected for JMS components')
 
     save()
-    activate()          
+    activate()
     print "~~~~COMMAND SUCCESFULL~~~~"
 
 except:
@@ -57,6 +63,3 @@ except:
     undo('true','y')
     stopEdit('y')
     raise
-
-
-


### PR DESCRIPTION
Hi Edwin,

I noticed that the wls_jms_topic and wls_jms_queue types did not interpreted the defaulttargetting parameters for the both. I also made a small change to wls_jms_connection_factory.

The logic goes in favorite of defaulttargetting if both defaulttargetting and subdeployment are set, because the first is the exception in our environment on the latter. I don't know if this is a common use case, so this might need some refactoring. I don't know what your experiences are on this topic.

Cheers!
Bas