### PR TITLE
Allow Same OPatch to Multiple Homes

### DIFF
--- a/lib/puppet/provider/opatch/opatch.rb
+++ b/lib/puppet/provider/opatch/opatch.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:opatch).provide(:opatch) do
 
   def opatch(action)
     user                    = resource[:os_user]
-    patchName               = resource[:name]
+    patchName               = resource[:patch_id]
     oracle_product_home_dir = resource[:oracle_product_home_dir]
     jdk_home_dir            = resource[:jdk_home_dir]
     extracted_patch_dir     = resource[:extracted_patch_dir]
@@ -38,7 +38,7 @@ Puppet::Type.type(:opatch).provide(:opatch) do
 
   def opatch_status
     user                    = resource[:os_user]
-    patchName               = resource[:name]
+    patchName               = resource[:patch_id]
     oracle_product_home_dir = resource[:oracle_product_home_dir]
     orainst_dir             = resource[:orainst_dir]
 
@@ -73,7 +73,7 @@ Puppet::Type.type(:opatch).provide(:opatch) do
 
   def status
     output  = opatch_status
-    patchId = resource[:name]
+    patchId = resource[:patch_id]
     Puppet.debug "opatch_status output #{output} for patchId #{patchId}"
     if output == patchId
       return :present

--- a/lib/puppet/type/opatch.rb
+++ b/lib/puppet/type/opatch.rb
@@ -39,7 +39,13 @@ module Puppet
       EOT
       isnamevar
     end
-
+    
+    newparam(:patch_id) do
+      desc <<-EOT
+        The patchId of the OPatch.
+      EOT
+    end
+    
     newparam(:os_user) do
       desc <<-EOT
         The weblogic operating system user.

--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -27,14 +27,16 @@ define orawls::opatch(
 
   if $ensure == 'present' {
     if $remote_file == true {
-      file { "${download_dir}/${patch_file}":
-        ensure => file,
-        source => "${mountPoint}/${patch_file}",
-        backup => false,
-        mode   => '0775',
-        owner  => $os_user,
-        group  => $os_group,
-        before => Exec["extract opatch ${patch_file} ${title}"],
+      if ! defined(File["${download_dir}/${patch_file}"]) {
+        file { "${download_dir}/${patch_file}":
+          ensure => file,
+          source => "${mountPoint}/${patch_file}",
+          backup => false,
+          mode   => '0775',
+          owner  => $os_user,
+          group  => $os_group,
+          before => Exec["extract opatch ${patch_file} ${title}"],
+        }
       }
       $disk1_file = "${download_dir}/${patch_file}"
     } else {
@@ -48,7 +50,7 @@ define orawls::opatch(
       user      => $os_user,
       group     => $os_group,
       logoutput => false,
-      before    => Opatch[$patch_id],
+      before    => Opatch["${patch_id} ${title}"],
     }
   }
 
@@ -64,8 +66,9 @@ define orawls::opatch(
     }
   }
 
-  opatch{ $patch_id:
+  opatch{ "${patch_id} ${title}":
     ensure                  => $ensure,
+    patch_id                => $patch_id,
     os_user                 => $os_user,
     oracle_product_home_dir => $oracle_product_home_dir,
     orainst_dir             => $oraInstPath,


### PR DESCRIPTION
OPatch definition is now differentiated on title, allowing same patch ID
to be applied to different homes.

This resolves Issue #221