### PR TITLE
Validate wls_deployment 'localpath' parameter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ desc "Run syntax, lint, and spec tests."
 task :default => [
 	:spec_prep,
 	:syntax,
-	:test,
+	:spec_standalone,
 	:lint,
 	:spec_clean
 ]

--- a/lib/puppet/type/wls_deployment/localpath.rb
+++ b/lib/puppet/type/wls_deployment/localpath.rb
@@ -2,8 +2,19 @@ newparam(:localpath) do
   include EasyType
 
   desc 'The local path of the artifact'
-
   isnamevar
+
+  validate do |value|
+    unless Pathname.new(value).absolute?
+      fail("#{value} is not an absolute path")
+    end
+
+    if Pathname.new(value).dirname.cleanpath.to_s == '/tmp'
+      #Weblogic 12.1.1 deployments will fail it localpath is directly in /tmp
+      fail("localpath can not be in /tmp")
+    end
+
+  end
 
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ end
 
 require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'pathname'
+
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 # include common helpers
 support_path = File.expand_path(File.join(File.dirname(__FILE__), '..','spec/support/*.rb'))
@@ -15,9 +17,12 @@ Dir[support_path].each {|f| require f}
 
 RSpec.configure do |c|
   c.config = '/doesnotexist'
-  c.module_path  = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/modules'))
   c.manifest_dir = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures/manifests'))
 end
+
+dir = Pathname.new(__FILE__).parent
+Puppet[:modulepath] = File.join(dir, 'fixtures', 'modules')
+Puppet[:libdir] = "#{Puppet[:modulepath]}/easy_type/lib"
 
 def param_value(subject, type, title, param)
   subject.resource(type, title).send(:parameters)[param.to_sym]

--- a/spec/unit/puppet/type/wls_deployment_spec.rb
+++ b/spec/unit/puppet/type/wls_deployment_spec.rb
@@ -1,0 +1,28 @@
+require 'puppet'
+require 'puppet/type/wls_deployment'
+
+describe Puppet::Type.type(:wls_deployment) do
+
+  before :each do
+    @deployment = Puppet::Type.type(:wls_deployment).new({:name => 'testdeployment', :localpath => '/an/absolute/path'})
+  end
+
+  describe 'localpath' do
+    it 'should accept an absolute path for localpath' do
+      expect(@deployment[:localpath]).to eq('/an/absolute/path')
+    end
+
+    it 'should fail if localpath isn\'t an absolute path' do
+      expect {
+        Puppet::Type.type(:wls_deployment).new({:name => 'testdeployment', :localpath => 'not_an_absolute_path'})
+      }.to raise_error(/not_an_absolute_path is not an absolute path/)
+    end
+
+    it 'should fail if localpath is in /tmp' do
+      expect {
+        Puppet::Type.type(:wls_deployment).new({:name => 'testdeployment', :localpath => '/tmp/app.war'})
+      }.to raise_error(/localpath can not be in \/tmp/)
+    end
+
+  end
+end


### PR DESCRIPTION
Fixes #239

With weblogic 12.1.1, wls_deployments would silently fail if the
deployment's localpath was in /tmp.

This patch validates that localpath is both an absolute path and not
directly under /tmp.