### PR TITLE
Add support for multiple base installations of same Fmw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 spec/reports
 pkg
+spec/fixtures

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -70,7 +70,7 @@ define orawls::fmw (
     else {
       $oracleHome = $oracle_home_dir
     }
-    $createFile1 = "${download_dir}/${fmw_product}/Disk1"
+    $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
     $total_files = 1
 
   } elsif ( $fmw_product == 'forms' ) {
@@ -82,15 +82,15 @@ define orawls::fmw (
       $oracleHome = $oracle_home_dir
     }
 
-    $createFile1 = "${download_dir}/${fmw_product}/Disk1"
+    $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
     if $version == 11112 {
       $total_files = 4
-      $createFile2 = "${download_dir}/${fmw_product}/Disk2"
-      $createFile3 = "${download_dir}/${fmw_product}/Disk3"
-      $createFile4 = "${download_dir}/${fmw_product}/Disk4"
+      $createFile2 = "${download_dir}/${sanitised_title}/Disk2"
+      $createFile3 = "${download_dir}/${sanitised_title}/Disk3"
+      $createFile4 = "${download_dir}/${sanitised_title}/Disk4"
     } elsif $version == 1112  {
       $total_files = 2
-      $createFile2 = "${download_dir}/${fmw_product}/Disk4"
+      $createFile2 = "${download_dir}/${sanitised_title}/Disk4"
     } else {
       $total_files = 1
     }
@@ -101,7 +101,7 @@ define orawls::fmw (
       $total_files = 1
       $fmw_silent_response_file = 'orawls/fmw_silent_soa_1213.rsp.erb'
       $binFile1                 = 'fmw_12.1.3.0.0_soa.jar'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $oracleHome               = "${middleware_home_dir}/soa/bin"
       $type                     = 'java'
       if $bpm == true {
@@ -113,8 +113,8 @@ define orawls::fmw (
     } else {
       $total_files = 2
       $fmw_silent_response_file = 'orawls/fmw_silent_soa.rsp.erb'
-      $createFile1 = "${download_dir}/${fmw_product}/Disk1"
-      $createFile2 = "${download_dir}/${fmw_product}/Disk4"
+      $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
+      $createFile2 = "${download_dir}/${sanitised_title}/Disk4"
       if ($oracle_home_dir == undef) {
         $oracleHome = "${middleware_home_dir}/Oracle_SOA1"
       }
@@ -129,12 +129,12 @@ define orawls::fmw (
     if $version == 1213 {
       $fmw_silent_response_file = 'orawls/fmw_silent_osb_1213.rsp.erb'
       $binFile1                 = 'fmw_12.1.3.0.0_osb.jar'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $oracleHome               = "${middleware_home_dir}/osb/bin"
       $type                     = 'java'
     } else {
       $fmw_silent_response_file = 'orawls/fmw_silent_osb.rsp.erb'
-      $createFile1 = "${download_dir}/${fmw_product}/Disk1"
+      $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
       if ($oracle_home_dir == undef) {
         $oracleHome = "${middleware_home_dir}/Oracle_OSB1"
       }
@@ -148,7 +148,7 @@ define orawls::fmw (
       $total_files = 1
       $fmw_silent_response_file = 'orawls/fmw_silent_b2b_1213.rsp.erb'
       $binFile1                 = 'fmw_12.1.3.0.0_b2bhealthcare.jar'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $oracleHome               = "${middleware_home_dir}/soa/soa/modules/oracle.soa.b2b_11.1.1/b2b.jar"
       $type                     = 'java'
       if $healthcare == true {
@@ -165,7 +165,7 @@ define orawls::fmw (
       $total_files = 1
       $fmw_silent_response_file = 'orawls/fmw_silent_mft_1213.rsp.erb'
       $binFile1                 = 'fmw_12.1.3.0.0_mft.jar'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $oracleHome               = "${middleware_home_dir}/mft/bin"
       $type                     = 'java'
 
@@ -181,8 +181,8 @@ define orawls::fmw (
     else {
       $oracleHome = $oracle_home_dir
     }
-    $createFile1 = "${download_dir}/${fmw_product}/Disk1"
-    $createFile2 = "${download_dir}/${fmw_product}/Disk4"
+    $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
+    $createFile2 = "${download_dir}/${sanitised_title}/Disk4"
     $total_files = 3
 
 
@@ -194,7 +194,7 @@ define orawls::fmw (
     else {
       $oracleHome = $oracle_home_dir
     }
-    $createFile1 = "${download_dir}/${fmw_product}/Disk1"
+    $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
     $total_files = 1
 
   } elsif ( $fmw_product == 'wcc' ) {
@@ -205,8 +205,8 @@ define orawls::fmw (
     else {
       $oracleHome = $oracle_home_dir
     }
-    $createFile1 = "${download_dir}/${fmw_product}/Disk1"
-    $createFile2 = "${download_dir}/${fmw_product}/Disk2"
+    $createFile1 = "${download_dir}/${sanitised_title}/Disk1"
+    $createFile2 = "${download_dir}/${sanitised_title}/Disk2"
     $total_files = 2
 
   } elsif ( $fmw_product == 'web') {
@@ -214,17 +214,17 @@ define orawls::fmw (
     if $version == 1212 {
       $fmw_silent_response_file = 'orawls/web_http_server_1212.rsp.erb'
       $binFile1                 = 'ohs_121200_linux64.bin'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $type                     = 'bin'
     }
     elsif $version == 1213 {
       $fmw_silent_response_file = 'orawls/web_http_server_1213.rsp.erb'
       $binFile1                 = 'fmw_12.1.3.0.0_ohs_linux64.bin'
-      $createFile1              = "${download_dir}/${fmw_product}/${binFile1}"
+      $createFile1              = "${download_dir}/${sanitised_title}/${binFile1}"
       $type                     = 'bin'
     } else {
       $fmw_silent_response_file = 'orawls/web_http_server.rsp.erb'
-      $createFile1              = "${download_dir}/${fmw_product}/Disk1"
+      $createFile1              = "${download_dir}/${sanitised_title}/Disk1"
     }
 
     if ($oracle_home_dir == undef) {
@@ -242,7 +242,7 @@ define orawls::fmw (
   } elsif ( $fmw_product == 'webgate' ) {
 
     $fmw_silent_response_file = 'orawls/fmw_webgate.rsp.erb'
-    $createFile1              = "${download_dir}/${fmw_product}/Disk1"
+    $createFile1              = "${download_dir}/${sanitised_title}/Disk1"
 
     if ($oracle_home_dir == undef) {
       $oracleHome = "${middleware_home_dir}/Oracle_OAMWebGate1"
@@ -255,7 +255,7 @@ define orawls::fmw (
   } elsif ( $fmw_product == 'oud' ) {
 
     $fmw_silent_response_file = 'orawls/fmw_silent_oud.rsp.erb'
-    $createFile1              = "${download_dir}/${fmw_product}/Disk1"
+    $createFile1              = "${download_dir}/${sanitised_title}/Disk1"
 
     if ($oracle_home_dir == undef) {
       $oracleHome = "${middleware_home_dir}/Oracle_OUD1"
@@ -295,19 +295,19 @@ define orawls::fmw (
       $mountPoint = $source
     }
 
-    orawls::utils::orainst { "create oraInst for ${fmw_product}":
+    orawls::utils::orainst { "create oraInst for ${name}":
       ora_inventory_dir => $oraInventory,
       os_group          => $os_group,
     }
 
-    file { "${download_dir}/${sanitised_title}_silent_${fmw_product}.rsp":
+    file { "${download_dir}/${sanitised_title}_silent.rsp":
       ensure  => present,
       content => template($fmw_silent_response_file),
       mode    => '0775',
       owner   => $os_user,
       group   => $os_group,
       backup  => false,
-      require => Orawls::Utils::Orainst["create oraInst for ${fmw_product}"],
+      require => Orawls::Utils::Orainst["create oraInst for ${name}"],
     }
 
     # for performance reasons, download and extract or just extract it
@@ -319,21 +319,21 @@ define orawls::fmw (
         owner  => $os_user,
         group  => $os_group,
         backup => false,
-        before => Exec["extract ${fmw_file1}"],
+        before => Exec["extract ${fmw_file1} for ${name}"],
       }
       $disk1_file = "${download_dir}/${fmw_file1}"
     } else {
       $disk1_file = "${source}/${fmw_file1}"
     }
 
-    exec { "extract ${fmw_file1}":
-      command   => "unzip -o ${disk1_file} -d ${download_dir}/${fmw_product}",
+    exec { "extract ${fmw_file1} for ${name}":
+      command   => "unzip -o ${disk1_file} -d ${download_dir}/${sanitised_title}",
       creates   => $createFile1,
       path      => $exec_path,
       user      => $os_user,
       group     => $os_group,
       logoutput => false,
-      require   => Orawls::Utils::Orainst["create oraInst for ${fmw_product}"],
+      require   => Orawls::Utils::Orainst["create oraInst for ${name}"],
     }
 
     # TODO: we should make a utility function to handle each file rather than copy/pasting and editing
@@ -349,24 +349,24 @@ define orawls::fmw (
           owner   => $os_user,
           group   => $os_group,
           backup  => false,
-          before  => Exec["extract ${fmw_file2}"],
+          before  => Exec["extract ${fmw_file2} for ${name}"],
           require => [File["${download_dir}/${fmw_file1}"],
-                      Exec["extract ${fmw_file1}"],],
+                      Exec["extract ${fmw_file1} for ${name}"],],
         }
         $disk2_file = "${download_dir}/${fmw_file2}"
       } else {
         $disk2_file = "${source}/${fmw_file2}"
       }
 
-      exec { "extract ${fmw_file2}":
-        command   => "unzip -o ${disk2_file} -d ${download_dir}/${fmw_product}",
+      exec { "extract ${fmw_file2} for ${name}":
+        command   => "unzip -o ${disk2_file} -d ${download_dir}/${sanitised_title}",
         creates   => $createFile2,
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
         logoutput => false,
-        require   => Exec["extract ${fmw_file1}"],
-        before    => Exec["install ${fmw_product} ${sanitised_title}"],
+        require   => Exec["extract ${fmw_file1} for ${name}"],
+        before    => Exec["install ${sanitised_title}"],
       }
     }
     if ( $total_files > 2 ) {
@@ -391,14 +391,14 @@ define orawls::fmw (
       }
 
       exec { "extract ${fmw_file3}":
-        command   => "unzip -o ${disk3_file} -d ${download_dir}/${fmw_product}",
+        command   => "unzip -o ${disk3_file} -d ${download_dir}/${sanitised_title}",
         creates   => $createFile3,
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
         logoutput => false,
         require   => Exec["extract ${fmw_file2}"],
-        before    => Exec["install ${fmw_product} ${sanitised_title}"],
+        before    => Exec["install ${sanitised_title}"],
       }
     }
     if ( $total_files > 3 ) {
@@ -423,14 +423,14 @@ define orawls::fmw (
       }
 
       exec { "extract ${fmw_file4}":
-        command   => "unzip -o ${disk4_file} -d ${download_dir}/${fmw_product}",
+        command   => "unzip -o ${disk4_file} -d ${download_dir}/${sanitised_title}",
         creates   => $createFile4,
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
         logoutput => false,
         require   => Exec["extract ${fmw_file3}"],
-        before    => Exec["install ${fmw_product} ${sanitised_title}"],
+        before    => Exec["install ${sanitised_title}"],
       }
     }
 
@@ -438,10 +438,10 @@ define orawls::fmw (
       if $version != 1213 {
         if $fmw_product == 'soa' {
           exec { "add -d64 oraparam.ini ${sanitised_title}":
-            command   => "sed -e's/JRE_MEMORY_OPTIONS=\" -Xverify:none\"/JRE_MEMORY_OPTIONS=\"-d64 -Xverify:none\"/g' ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini > ${temp_directory}/soa.tmp && mv ${temp_directory}/soa.tmp ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini",
-            unless    => "grep 'JRE_MEMORY_OPTIONS=\"-d64' ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini",
-            require   => Exec["extract ${fmw_file1}","extract ${fmw_file2}"],
-            before    => Exec["install ${fmw_product} ${sanitised_title}"],
+            command   => "sed -e's/JRE_MEMORY_OPTIONS=\" -Xverify:none\"/JRE_MEMORY_OPTIONS=\"-d64 -Xverify:none\"/g' ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini > ${temp_directory}/soa.tmp && mv ${temp_directory}/soa.tmp ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini",
+            unless    => "grep 'JRE_MEMORY_OPTIONS=\"-d64' ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini",
+            require   => Exec["extract ${fmw_file1} for ${name}","extract ${fmw_file2}"],
+            before    => Exec["install ${sanitised_title}"],
             path      => $exec_path,
             user      => $os_user,
             group     => $os_group,
@@ -450,10 +450,10 @@ define orawls::fmw (
         }
         if $fmw_product == 'osb' {
           exec { "add -d64 oraparam.ini ${sanitised_title}":
-            command   => "sed -e's/\\[Oracle\\]/\\[Oracle\\]\\\nJRE_MEMORY_OPTIONS=\"-d64\"/g' ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini > ${temp_directory}/osb.tmp && mv ${temp_directory}/osb.tmp ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini",
-            unless    => "grep 'JRE_MEMORY_OPTIONS=\"-d64\"' ${download_dir}/${fmw_product}/Disk1/install/${installDir}/oraparam.ini",
-            require   => Exec["extract ${fmw_file1}"],
-            before    => Exec["install ${fmw_product} ${sanitised_title}"],
+            command   => "sed -e's/\\[Oracle\\]/\\[Oracle\\]\\\nJRE_MEMORY_OPTIONS=\"-d64\"/g' ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini > ${temp_directory}/osb.tmp && mv ${temp_directory}/osb.tmp ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini",
+            unless    => "grep 'JRE_MEMORY_OPTIONS=\"-d64\"' ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini",
+            require   => Exec["extract ${fmw_file1} for ${name}"],
+            before    => Exec["install ${sanitised_title}"],
             path      => $exec_path,
             user      => $os_user,
             group     => $os_group,
@@ -463,7 +463,7 @@ define orawls::fmw (
       }
     }
 
-    $command = "-silent -response ${download_dir}/${sanitised_title}_silent_${fmw_product}.rsp -waitforcompletion"
+    $command = "-silent -response ${download_dir}/${sanitised_title}_silent.rsp -waitforcompletion"
 
     if $version == 1212 or $version == 1213 {
       if $type == 'java' {
@@ -473,8 +473,8 @@ define orawls::fmw (
         $install = ''
       }
 
-      exec { "install ${fmw_product} ${sanitised_title}":
-        command     => "${install}${download_dir}/${fmw_product}/${binFile1} ${command} -invPtrLoc ${oraInstPath}/oraInst.loc -ignoreSysPrereqs -jreLoc ${jdk_home_dir}",
+      exec { "install ${sanitised_title}":
+        command     => "${install}${download_dir}/${sanitised_title}/${binFile1} ${command} -invPtrLoc ${oraInstPath}/oraInst.loc -ignoreSysPrereqs -jreLoc ${jdk_home_dir}",
         environment => "TEMP=${temp_directory}",
         timeout     => 0,
         creates     => $oracleHome,
@@ -482,9 +482,9 @@ define orawls::fmw (
         user        => $os_user,
         group       => $os_group,
         logoutput   => $log_output,
-        require     => [File["${download_dir}/${sanitised_title}_silent_${fmw_product}.rsp"],
-                        Orawls::Utils::Orainst["create oraInst for ${fmw_product}"],
-                        Exec["extract ${fmw_file1}"],],
+        require     => [File["${download_dir}/${sanitised_title}_silent.rsp"],
+                        Orawls::Utils::Orainst["create oraInst for ${name}"],
+                        Exec["extract ${fmw_file1} for ${name}"],],
       }
     } else {
       if !defined(File[$oracleHome]) {
@@ -492,12 +492,12 @@ define orawls::fmw (
           ensure => 'directory',
           owner  => $os_user,
           group  => $os_group,
-          before => Exec["install ${fmw_product} ${sanitised_title}"],
+          before => Exec["install ${sanitised_title}"],
         }
       }
 
-      exec { "install ${fmw_product} ${sanitised_title}":
-        command     => "/bin/sh -c 'unset DISPLAY;${download_dir}/${fmw_product}/Disk1/install/${installDir}/runInstaller ${command} -invPtrLoc ${oraInstPath}/oraInst.loc -ignoreSysPrereqs -jreLoc ${jdk_home_dir} -Djava.io.tmpdir=${temp_directory}'",
+      exec { "install ${sanitised_title}":
+        command     => "/bin/sh -c 'unset DISPLAY;${download_dir}/${sanitised_title}/Disk1/install/${installDir}/runInstaller ${command} -invPtrLoc ${oraInstPath}/oraInst.loc -ignoreSysPrereqs -jreLoc ${jdk_home_dir} -Djava.io.tmpdir=${temp_directory}'",
         environment => "TEMP=${temp_directory}",
         timeout     => 0,
         creates     => "${oracleHome}/OPatch",
@@ -505,39 +505,39 @@ define orawls::fmw (
         user        => $os_user,
         group       => $os_group,
         logoutput   => $log_output,
-        require     => [File["${download_dir}/${sanitised_title}_silent_${fmw_product}.rsp"],
-                        Orawls::Utils::Orainst["create oraInst for ${fmw_product}"],
-                        Exec["extract ${fmw_file1}"],],
+        require     => [File["${download_dir}/${sanitised_title}_silent.rsp"],
+                        Orawls::Utils::Orainst["create oraInst for ${name}"],
+                        Exec["extract ${fmw_file1} for ${name}"],],
       }
 
       ## fix EditHttpConf in OHS Webgate
       if ( $version == 1112 and $fmw_product == 'webgate' ) {
-        exec { "install ${fmw_product} ${sanitised_title} EditHttpConf1":
-          command   => "unzip -o -j '${download_dir}/${fmw_product}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/lib/libxmlengine.so' -d '${oracleHome}/webgate/ohs/lib/'",
+        exec { "install ${sanitised_title} EditHttpConf1":
+          command   => "unzip -o -j '${download_dir}/${sanitised_title}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/lib/libxmlengine.so' -d '${oracleHome}/webgate/ohs/lib/'",
           timeout   => 0,
           path      => $exec_path,
           user      => $os_user,
           group     => $os_group,
           logoutput => $log_output,
-          require   => Exec["install ${fmw_product} ${sanitised_title}"],
+          require   => Exec["install ${sanitised_title}"],
         }
-        exec { "install ${fmw_product} ${sanitised_title} EditHttpConf2":
-          command   => "unzip -o -j '${download_dir}/${fmw_product}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/lib/webgate.so' -d '${oracleHome}/webgate/ohs/lib/'",
+        exec { "install ${sanitised_title} EditHttpConf2":
+          command   => "unzip -o -j '${download_dir}/${sanitised_title}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/lib/webgate.so' -d '${oracleHome}/webgate/ohs/lib/'",
           timeout   => 0,
           path      => $exec_path,
           user      => $os_user,
           group     => $os_group,
           logoutput => $log_output,
-          require   => Exec["install ${fmw_product} ${sanitised_title}"],
+          require   => Exec["install ${sanitised_title}"],
         }
-        exec { "install ${fmw_product} ${sanitised_title} EditHttpConf3":
-          command   => "unzip -o -j '${download_dir}/${fmw_product}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/tools/setup/InstallTools/EditHttpConf' -d '${oracleHome}/webgate/ohs/tools/setup/InstallTools/'",
+        exec { "install ${sanitised_title} EditHttpConf3":
+          command   => "unzip -o -j '${download_dir}/${sanitised_title}/Disk1/stage/Components/oracle.as.oam.webgate.ohs_linux64/11.1.2.2.0/1/DataFiles/filegroup1.jar' 'webgate/ohs/tools/setup/InstallTools/EditHttpConf' -d '${oracleHome}/webgate/ohs/tools/setup/InstallTools/'",
           timeout   => 0,
           path      => $exec_path,
           user      => $os_user,
           group     => $os_group,
           logoutput => $log_output,
-          require   => Exec["install ${fmw_product} ${sanitised_title}"],
+          require   => Exec["install ${sanitised_title}"],
         }
         file { "${oracleHome}/webgate/ohs/tools/setup/InstallTools/EditHttpConf":
           ensure  => file,
@@ -545,7 +545,7 @@ define orawls::fmw (
           owner   => $os_user,
           group   => $os_group,
           backup  => false,
-          require => Exec["install ${fmw_product} ${sanitised_title} EditHttpConf3"],
+          require => Exec["install ${sanitised_title} EditHttpConf3"],
         }
       }
     }

--- a/spec/defines/fmw_remote_spec.rb
+++ b/spec/defines/fmw_remote_spec.rb
@@ -31,7 +31,7 @@ describe 'orawls::fmw', :type => :define do
 
     describe "SOA Suite orainst" do
       it do 
-        should contain_orawls__utils__orainst('create oraInst for soa').with({
+        should contain_orawls__utils__orainst('create oraInst for soaPS6').with({
              'ora_inventory_dir'  => '/opt/oracle/oraInventory',
              'os_group'           => 'dba',
            })
@@ -41,7 +41,7 @@ describe 'orawls::fmw', :type => :define do
 
     describe "for SOA Suite response file" do
       it do 
-        should contain_file("/install/soaPS6_silent_soa.rsp")
+        should contain_file("/install/soaPS6_silent.rsp")
       end
     end
 
@@ -49,51 +49,57 @@ describe 'orawls::fmw', :type => :define do
       it { 
            should contain_file("/install/file1").with({
              'source'  => '/mnt/file1',
-           }).that_comes_before('Exec[extract file1]')  
+           }).that_comes_before('Exec[extract file1 for soaPS6]')  
          }  
     end
 
     describe "extract SOA Suite file1" do
       it { 
-           should contain_exec("extract file1").with({
-             'command'  => 'unzip -o /install/file1 -d /install/soa',
-             'creates'  => '/install/soa/Disk1',
-           }).that_requires('Orawls::Utils::Orainst[create oraInst for soa]')  
+           should contain_exec("extract file1 for soaPS6")
+             .with({
+               'command'  => 'unzip -o /install/file1 -d /install/soaPS6',
+               'creates'  => '/install/soaPS6/Disk1'})
+             .that_requires('Orawls::Utils::Orainst[create oraInst for soaPS6]')  
          }  
     end
 
     describe "for SOA Suite file2" do
       it do 
-        should contain_file("/install/file2").with({
-             'source'  => '/mnt/file2',
-           }).that_comes_before('Exec[extract file2]')  
+        should contain_file("/install/file2")
+          .with({'source'  => '/mnt/file2'})
+          .that_comes_before('Exec[extract file2 for soaPS6]')  
       end
     end
 
     describe "extract SOA Suite file2" do
       it { 
-           should contain_exec("extract file2").with({
-             'command'  => 'unzip -o /install/file2 -d /install/soa',
-             'creates'  => '/install/soa/Disk4',
-           }).that_requires('Exec[extract file1]').that_comes_before('Exec[install soa soaPS6]')   
+           should contain_exec("extract file2 for soaPS6")
+            .with({
+               'command'  => 'unzip -o /install/file2 -d /install/soaPS6',
+               'creates'  => '/install/soaPS6/Disk4'})
+            .that_requires('Exec[extract file1 for soaPS6]')
+            .that_comes_before('Exec[install soaPS6]')   
          }  
     end
 
 
     describe "create Oracle home" do
       it do 
-        should contain_file("/opt/oracle/middleware11gR1/Oracle_SOA1").with({
-             'ensure'  => 'directory',
-          }).that_comes_before('Exec[install soa soaPS6]')   
+        should contain_file("/opt/oracle/middleware11gR1/Oracle_SOA1")
+          .with({'ensure'  => 'directory'})
+          .that_comes_before('Exec[install soaPS6]')   
       end
     end
 
     describe "install SOA Suite" do
       it { 
-           should contain_exec("install soa soaPS6").with({
-             'command'      => "/bin/sh -c 'unset DISPLAY;/install/soa/Disk1/install/linux64/runInstaller -silent -response /install/soaPS6_silent_soa.rsp -waitforcompletion -invPtrLoc /etc/oraInst.loc -ignoreSysPrereqs -jreLoc /usr/java/jdk1.7.0_45 -Djava.io.tmpdir=/tmp'",
-             'environment'  => 'TEMP=/tmp',
-           }).that_requires('File[/install/soaPS6_silent_soa.rsp]').that_requires('Orawls::Utils::Orainst[create oraInst for soa]').that_requires('Exec[extract file1]')     
+           should contain_exec("install soaPS6")
+           .with({
+             'command'      => "/bin/sh -c 'unset DISPLAY;/install/soaPS6/Disk1/install/linux64/runInstaller -silent -response /install/soaPS6_silent.rsp -waitforcompletion -invPtrLoc /etc/oraInst.loc -ignoreSysPrereqs -jreLoc /usr/java/jdk1.7.0_45 -Djava.io.tmpdir=/tmp'",
+             'environment'  => 'TEMP=/tmp'})
+           .that_requires('File[/install/soaPS6_silent.rsp]')
+           .that_requires('Orawls::Utils::Orainst[create oraInst for soaPS6]')
+           .that_requires('Exec[extract file1 for soaPS6]')     
          }  
     end
 
@@ -129,42 +135,47 @@ describe 'orawls::fmw', :type => :define do
 
     describe "OSB orainst" do
       it do 
-        should contain_orawls__utils__orainst('create oraInst for osb').with({
+        should contain_orawls__utils__orainst('create oraInst for osbPS6')
+          .with({
              'ora_inventory_dir'  => '/opt/oracle/oraInventory',
              'os_group'           => 'dba',
-           })
+          })
       end
     end
 
     describe "for OSB response file" do
       it do 
-        should contain_file("/install/osbPS6_silent_osb.rsp")
+        should contain_file("/install/osbPS6_silent.rsp")
       end
     end
 
     describe "extract OSB file1" do
       it { 
-           should contain_exec("extract file1").with({
-             'command'  => 'unzip -o /mnt/file1 -d /install/osb',
-             'creates'  => '/install/osb/Disk1',
-           }).that_requires('Orawls::Utils::Orainst[create oraInst for osb]')  
+           should contain_exec("extract file1 for osbPS6")
+            .with({
+               'command'  => 'unzip -o /mnt/file1 -d /install/osbPS6',
+               'creates'  => '/install/osbPS6/Disk1'})
+            .that_requires('Orawls::Utils::Orainst[create oraInst for osbPS6]')  
          }  
     end
 
     describe "create Oracle home" do
       it do 
-        should contain_file("/opt/oracle/middleware11gR1/Oracle_OSB1").with({
-             'ensure'  => 'directory',
-          }).that_comes_before('Exec[install osb osbPS6]')   
+        should contain_file("/opt/oracle/middleware11gR1/Oracle_OSB1")
+          .with({'ensure'  => 'directory'})
+          .that_comes_before('Exec[install osbPS6]')   
       end
     end
 
     describe "install OSB" do
       it { 
-           should contain_exec("install osb osbPS6").with({
-             'command'      => "/bin/sh -c 'unset DISPLAY;/install/osb/Disk1/install/linux/runInstaller -silent -response /install/osbPS6_silent_osb.rsp -waitforcompletion -invPtrLoc /etc/oraInst.loc -ignoreSysPrereqs -jreLoc /usr/java/jdk1.7.0_45 -Djava.io.tmpdir=/tmp1'",
-             'environment'  => 'TEMP=/tmp1',
-           }).that_requires('File[/install/osbPS6_silent_osb.rsp]').that_requires('Orawls::Utils::Orainst[create oraInst for osb]').that_requires('Exec[extract file1]')     
+           should contain_exec("install osbPS6")
+            .with({
+               'command'      => "/bin/sh -c 'unset DISPLAY;/install/osbPS6/Disk1/install/linux/runInstaller -silent -response /install/osbPS6_silent.rsp -waitforcompletion -invPtrLoc /etc/oraInst.loc -ignoreSysPrereqs -jreLoc /usr/java/jdk1.7.0_45 -Djava.io.tmpdir=/tmp1'",
+               'environment'  => 'TEMP=/tmp1'})
+            .that_requires('File[/install/osbPS6_silent.rsp]')
+            .that_requires('Orawls::Utils::Orainst[create oraInst for osbPS6]')
+            .that_requires('Exec[extract file1 for osbPS6]')     
          }  
     end
 

--- a/spec/defines/fmw_spec.rb
+++ b/spec/defines/fmw_spec.rb
@@ -74,6 +74,6 @@ describe 'orawls::fmw', :type => :define do
                    :kernel          => 'Linux',
                    :osfamily        => 'RedHat' }}
     it { is_expected.to compile }
-    it { is_expected.to contain_file("/install/My_Oracle-SOA_Installation_silent_soa.rsp") }
+    it { is_expected.to contain_file("/install/My_Oracle-SOA_Installation_silent.rsp") }
   end
 end


### PR DESCRIPTION
The current version of fmw, doesn't support the installation of the same middleware more than once. If you try, you get duplicate resources.  If however you want to have a middleware home for SOA and one for BAM and apply different patches to these, you'll need to do just that. This PR add's support for installing multiple homes with the same version. You will have to use different titles to the fmw to do this.  After this you can use opatch to differentiate the middleware homes