### PR TITLE
Prefetching wls_opatch type

### DIFF
--- a/lib/puppet/provider/wls_opatch/prefetching.rb
+++ b/lib/puppet/provider/wls_opatch/prefetching.rb
@@ -1,0 +1,56 @@
+require 'easy_type'
+require 'utils/wls_access'
+
+Puppet::Type.type(:wls_opatch).provide(:prefetching) do
+  include EasyType::Provider
+
+  include EasyType::Provider
+
+  desc 'Apply Oracle OPatches'
+
+  mk_resource_methods
+
+  def self.prefetch(resources)
+    os_user = check_single_os_user(resources)
+    all_patches = oracle_homes(resources).collect {|h| patches_in_home(h, os_user)}.flatten
+    resources.keys.each do |patch_name| 
+      if all_patches.include?(patch_name)
+        resources[patch_name].provider = new(:name => name, :ensure => :present)
+      end
+    end
+  end
+
+  def opatch(command)
+    oracle_product_home_dir = resource[:oracle_product_home_dir]
+    jre_specfied            = resource[:jdk_home_dir] ? " -jre #{resource[:jdk_home_dir]} " : ''
+    orainst_specified       = resource[:orainst_dir] ? " -invPtrLoc #{resource[:orainst_dir]} " : ''
+    os_user                 = resource[:os_user]
+    full_command            = "#{oracle_product_home_dir}/OPatch/opatch #{command} -oh #{oracle_product_home_dir} #{jre_specfied} #{orainst_specified}"
+    Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
+  end
+
+  private
+
+  def installed_patches
+    opatch('lsinventory').scan(/Patch\s.(\d+)\s.*:\sapplied on/).flatten
+  end
+
+  def self.patches_in_home(oracle_product_home_dir, os_user)
+    full_command  = "#{oracle_product_home_dir}/OPatch/opatch lsinventory -oh #{oracle_product_home_dir}"
+    raw_list = Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
+    patch_ids = raw_list.scan(/Patch\s.(\d+)\s.*:\sapplied on/).flatten
+    patch_ids.collect{|p| "#{oracle_product_home_dir}:#{p}"}
+  end
+
+  def self.check_single_os_user(resources)
+    os_users = resources.map{|k,v| v.os_user}.uniq
+    fail "wls_opatch doesn't support multiple os_users" if os_users.size > 1
+    os_users.first
+  end
+
+  def self.oracle_homes(resources)
+    resources.map{|k,v| v.oracle_product_home_dir}.uniq
+  end
+
+end
+

--- a/lib/puppet/provider/wls_opatch/prefetching.rb
+++ b/lib/puppet/provider/wls_opatch/prefetching.rb
@@ -26,7 +26,9 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
     orainst_specified       = resource[:orainst_dir] ? " -invPtrLoc #{resource[:orainst_dir]} " : ''
     os_user                 = resource[:os_user]
     full_command            = "#{oracle_product_home_dir}/OPatch/opatch #{command} -oh #{oracle_product_home_dir} #{jre_specfied} #{orainst_specified}"
-    Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
+    output = Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
+    Puppet.debug output
+    output
   end
 
   private
@@ -38,6 +40,7 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
   def self.patches_in_home(oracle_product_home_dir, os_user)
     full_command  = "#{oracle_product_home_dir}/OPatch/opatch lsinventory -oh #{oracle_product_home_dir}"
     raw_list = Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
+    Puppet.debug raw_list 
     patch_ids = raw_list.scan(/Patch\s.(\d+)\s.*:\sapplied on/).flatten
     patch_ids.collect{|p| "#{oracle_product_home_dir}:#{p}"}
   end

--- a/lib/puppet/type/wls_opatch.rb
+++ b/lib/puppet/type/wls_opatch.rb
@@ -64,12 +64,10 @@ module Puppet
       fail "puppet url's not (yet) supported."
     end
 
-
     def unzip(file)
       output = "/tmp/wls_opatch"
       Puppet.debug "Unzipping source #{source} to #{output}"
-      `unzip -o #{file} -d '#{output}'`
-      FileUtils.chmod_R(0777,output)
+      Puppet::Util::Execution.execute("/usr/bin/unzip -o #{file} -d #{output}" , :failonfail => true, :uid => os_user)
       "#{output}/#{patch_id}"
     end
 

--- a/lib/puppet/type/wls_opatch.rb
+++ b/lib/puppet/type/wls_opatch.rb
@@ -1,0 +1,79 @@
+require File.dirname(__FILE__) + '/../../orawls_core'
+
+
+module Puppet
+  #
+  Type.newtype(:wls_opatch) do
+    include EasyType
+    include Utils::WlsAccess
+    extend Utils::TitleParser
+
+    desc 'This resource allows you to manage opatch patches on a specific middleware home.'
+
+    ensurable
+
+    set_command(:opatch)
+
+    on_create  do | command_builder |
+      if is_puppet_url?(source)
+        fetched_source = fetch_source(source)
+      else
+        fetched_source = source
+      end
+      if is_zipfile?(fetched_source)
+        extracted_source = unzip(fetched_source) 
+      else
+        extracted_source = "#{source}/#{patch_id}"
+      end
+      "apply #{extracted_source} -silent "
+    end
+
+    on_modify  do | command_builder |
+      fail "Internal error. A patch is either there ot not. It cannot be modified."
+    end
+
+    on_destroy  do | command_builder |
+      "rollback -id #{patch_id} -silent "
+    end
+
+    map_title_to_attributes(:name, :oracle_product_home_dir, :patch_id) do
+      /^((.*):(.*))$/
+    end
+
+    parameter :name
+    parameter :patch_id
+    parameter :os_user
+    parameter :oracle_product_home_dir
+    parameter :jdk_home_dir
+    parameter :source
+    parameter :orainst_dir
+
+    def opatch(command, options = {})
+      provider.opatch(command)
+    end
+
+    def is_puppet_url?(url)
+      url.scan(/^puppet:\/\/.*$/) != []
+    end
+
+    def is_zipfile?(file)
+      Pathname(file).extname.downcase == '.zip'
+    end
+
+    def fetch_source(file)
+      fail "puppet url's not (yet) supported."
+    end
+
+
+    def unzip(file)
+      output = "/tmp/wls_opatch"
+      Puppet.debug "Unzipping source #{source} to #{output}"
+      `unzip -o #{file} -d '#{output}'`
+      FileUtils.chmod_R(0777,output)
+      "#{output}/#{patch_id}"
+    end
+
+  end
+
+
+end

--- a/lib/puppet/type/wls_opatch/jdk_home_dir.rb
+++ b/lib/puppet/type/wls_opatch/jdk_home_dir.rb
@@ -1,0 +1,5 @@
+newparam(:jdk_home_dir) do
+  desc <<-EOT
+    The JDK home folder.
+  EOT
+end

--- a/lib/puppet/type/wls_opatch/oracle_product_home_dir.rb
+++ b/lib/puppet/type/wls_opatch/oracle_product_home_dir.rb
@@ -1,0 +1,5 @@
+newparam(:oracle_product_home_dir) do
+  desc <<-EOT
+    The oracle product home folder.
+  EOT
+end

--- a/lib/puppet/type/wls_opatch/orainst_dir.rb
+++ b/lib/puppet/type/wls_opatch/orainst_dir.rb
@@ -1,0 +1,5 @@
+newparam(:orainst_dir) do
+  desc <<-EOT
+    The orainst folder.
+  EOT
+end

--- a/lib/puppet/type/wls_opatch/os_user.rb
+++ b/lib/puppet/type/wls_opatch/os_user.rb
@@ -1,0 +1,5 @@
+newparam(:os_user) do
+  desc <<-EOT
+    The weblogic operating system user.
+  EOT
+end

--- a/lib/puppet/type/wls_opatch/patch_id.rb
+++ b/lib/puppet/type/wls_opatch/patch_id.rb
@@ -1,0 +1,5 @@
+newparam(:patch_id) do
+  desc <<-EOT
+    The patchId of the OPatch.
+  EOT
+end

--- a/lib/puppet/type/wls_opatch/source.rb
+++ b/lib/puppet/type/wls_opatch/source.rb
@@ -1,0 +1,5 @@
+newparam(:source) do
+  desc <<-EOT
+    The esource of the patch. Can be either an extracted folder or the raw zip file.
+  EOT
+end


### PR DESCRIPTION
Create's a `wls_opatch`  type. This type is a little bit smarter than the existing `opatch`. 

- It only does an index operation once. This means dramatic speed improvements when applying a lot of patches.
- it can unzip the provided file. It will only do this if it decides the patch must be installed.  This means no more exec's doing needless unzips.

Although not implemented yet, it is prepared for using `puppet:\\....` source files. This means it can fetch the file from a Puppet file server, but will only do this if it has decided the patch needs to be installed. Again this will take care of the needless fetching of large patch files.

You can use the type like this:

```puppet
wls_opatch{'/middleware_home_dir:patch_number':
  ensure   => present
  os_user  => 'weblogic'
  os_group => 'oinstal',
  source   => '/location_of/patchfile.zip'
}
```
Source is best used when specifying the zip file. But you can also specify a directory. In that case, the type will not unzip anything, but will use the specfied directory as source for opatch.

If needed, you can also specify extra parameters:

```puppet
wls_opatch{'/middleware_home_dir:patch_number':
  ensure       => present
  os_user      => 'weblogic'
  os_group     => 'oinstal',
  source       => '/location_of/patchfile.zip',
  jdk_home_dir => '/your/own/jdk_dir',
  orainst_dir  => '/where/your/oraInst.loc_file_exists/',   # This needs to be a directory
}
```

