### PR TITLE
Add cast to patch id comparison

### DIFF
--- a/lib/puppet/provider/opatch/opatch.rb
+++ b/lib/puppet/provider/opatch/opatch.rb
@@ -51,10 +51,11 @@ Puppet::Type.type(:opatch).provide(:opatch) do
     output = `su #{su_shell} - #{user} -c '#{command}'`
 
     output.each_line do |li|
-      opatch = li[5, li.index(':') - 5].strip + ';' if li['Patch'] && li[': applied on']
+      opatch = li[5, li.index(':') - 5].strip if li['Patch'] && li[': applied on']
       unless opatch.nil?
         Puppet.debug "line #{opatch}"
-        if opatch.include? patchName
+        patchNum = patchName.to_i
+        if opatch.to_i == patchNum
           Puppet.debug 'found patch'
           return patchName
         end


### PR DESCRIPTION
Due to strange issues with Opatch not detecting patches applied to the
local system, this change has been made after it being tested
succesfully.

Fixes #245