### PR TITLE
Add debug capabilities to orawls

### DIFF
--- a/lib/puppet/type/wls_setting.rb
+++ b/lib/puppet/type/wls_setting.rb
@@ -22,6 +22,7 @@ module Puppet
     property :weblogic_password
     property :post_classpath
     property :debug_module
+    property :archive_path
 
     property :custom_trust
     property :trust_keystore_file

--- a/lib/puppet/type/wls_setting.rb
+++ b/lib/puppet/type/wls_setting.rb
@@ -21,6 +21,7 @@ module Puppet
     property :connect_url
     property :weblogic_password
     property :post_classpath
+    property :debug_module
 
     property :custom_trust
     property :trust_keystore_file

--- a/lib/puppet/type/wls_setting/archive_path.rb
+++ b/lib/puppet/type/wls_setting/archive_path.rb
@@ -1,0 +1,12 @@
+newproperty(:archive_path) do
+  include EasyType
+
+  desc 'the archive path for WLST scripts we want to keep'
+
+  defaultto '/tmp/orawls-archive'
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/lib/puppet/type/wls_setting/debug_module.rb
+++ b/lib/puppet/type/wls_setting/debug_module.rb
@@ -1,0 +1,13 @@
+newproperty(:debug_module) do
+  include EasyType
+
+  desc 'Toggles retaining of WLST Python scripts'
+
+  newvalues(:true, :false)
+  defaultto :false
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource[self.name]
+  end
+
+end

--- a/lib/utils/wls_access.rb
+++ b/lib/utils/wls_access.rb
@@ -92,7 +92,7 @@ module Utils
 
       wls_daemon = WlsDaemon.run(operatingSystemUser, domain, weblogicHomeDir, weblogicUser, weblogicPassword, weblogicConnectUrl, postClasspath, custom_trust, trust_keystore_file, trust_keystore_passphrase)
 
-      if debug_module == 'true'
+      if debug_module.to_s == 'true'
         if !File.directory?('/tmp/orawls-archive')
           FileUtils.mkdir('/tmp/orawls-archive')
         end

--- a/lib/utils/wls_access.rb
+++ b/lib/utils/wls_access.rb
@@ -76,6 +76,7 @@ module Utils
       trust_keystore_file       = domainValues['trust_keystore_file']
       trust_keystore_passphrase = domainValues['trust_keystore_passphrase']
       debug_module              = domainValues['debug_module']
+      archive_path              = domainValues['archive_path']
 
       fail('weblogic_home_dir cannot be nil, check the wls_setting resource type') if weblogicHomeDir.nil?
       fail('weblogic_password cannot be nil, check the wls_setting resource type') if weblogicPassword.nil?
@@ -93,10 +94,10 @@ module Utils
       wls_daemon = WlsDaemon.run(operatingSystemUser, domain, weblogicHomeDir, weblogicUser, weblogicPassword, weblogicConnectUrl, postClasspath, custom_trust, trust_keystore_file, trust_keystore_passphrase)
 
       if debug_module.to_s == 'true'
-        if !File.directory?('/tmp/orawls-archive')
-          FileUtils.mkdir('/tmp/orawls-archive')
+        if !File.directory?(archive_path)
+          FileUtils.mkdir(archive_path)
         end
-        FileUtils.cp(tmpFile.path, '/tmp/orawls-archive/')
+        FileUtils.cp(tmpFile.path, archive_path)
       end
 
       if timeout_specified

--- a/lib/utils/wls_access.rb
+++ b/lib/utils/wls_access.rb
@@ -75,6 +75,7 @@ module Utils
       custom_trust              = domainValues['custom_trust']
       trust_keystore_file       = domainValues['trust_keystore_file']
       trust_keystore_passphrase = domainValues['trust_keystore_passphrase']
+      debug_module              = domainValues['debug_module']
 
       fail('weblogic_home_dir cannot be nil, check the wls_setting resource type') if weblogicHomeDir.nil?
       fail('weblogic_password cannot be nil, check the wls_setting resource type') if weblogicPassword.nil?
@@ -90,6 +91,14 @@ module Utils
       end
 
       wls_daemon = WlsDaemon.run(operatingSystemUser, domain, weblogicHomeDir, weblogicUser, weblogicPassword, weblogicConnectUrl, postClasspath, custom_trust, trust_keystore_file, trust_keystore_passphrase)
+
+      if debug_module == 'true'
+        if !File.directory?('/tmp/orawls-archive')
+          FileUtils.mkdir('/tmp/orawls-archive')
+        end
+        FileUtils.cp(tmpFile.path, '/tmp/orawls-archive/')
+      end
+
       if timeout_specified
         wls_daemon.execute_script(tmpFile.path, timeout_specified)
       else


### PR DESCRIPTION
This commit adds the use of a temp directory to orawls. When you create
the following line in wls_settings on the host the module is ran,
orawls will copy all the scripts created as tempfiles to
/tmp/orawls-archive. This is useful when new or modified types are debugged.

debug_module: "true"

wls_settings needs to be changed, so we can puppetize this value as
well.