### PR TITLE
Add ability to manage nodemanager properties file.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,5 +8,7 @@ fixtures:
       repo: 'git://github.com/adrienthebo/puppet-filemapper'
     'sleep':
       repo: 'git://github.com/fiddyspence/puppet-sleep'
+    'stdlib':
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
   symlinks:
     'orawls': '#{source_dir}'

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -128,24 +128,24 @@ define orawls::nodemanager (
   }
 
   $property_defaults = {
-    'log_limit'                          => '0',
-    'domains_dir_remote_sharing_enabled' => 'false',
-    'authentication_enabled'             => 'true',
+    'log_limit'                          => 0,
+    'domains_dir_remote_sharing_enabled' => false,
+    'authentication_enabled'             => true,
     'log_level'                          => 'INFO',
-    'domains_file_enabled'               => 'true',
+    'domains_file_enabled'               => true,
     'start_script_name'                  => 'startWebLogic.sh',
-    'native_version_enabled'             => 'true',
-    'log_to_stderr'                      => 'true',
+    'native_version_enabled'             => true,
+    'log_to_stderr'                      => true,
     'log_count'                          => '1',
-    'domain_registration_enabled'        => 'false',
-    'stop_script_enabled'                => 'true',
-    'quit_enabled'                       => 'false',
-    'log_append'                         => 'true',
-    'state_check_interval'               => '500',
-    'crash_recovery_enabled'             => 'true',
-    'start_script_enabled'               => 'true',
+    'domain_registration_enabled'        => false,
+    'stop_script_enabled'                => true,
+    'quit_enabled'                       => false,
+    'log_append'                         => true,
+    'state_check_interval'               => 500,
+    'crash_recovery_enabled'             => true,
+    'start_script_enabled'               => true,
     'log_formatter'                      => 'weblogic.nodemanager.server.LogFormatter',
-    'listen_backlog'                     => '50',
+    'listen_backlog'                     => 50,
   }
 
   $properties_merged = merge($property_defaults, $properties)

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -27,6 +27,7 @@ define orawls::nodemanager (
   $log_dir                               = hiera('wls_log_dir'                   , undef), # /data/logs
   $log_output                            = false, # true|false
   $sleep                                 = hiera('wls_nodemanager_sleep'         , 20), # default sleep time
+  $properties                            = {},
 )
 {
 
@@ -125,6 +126,29 @@ define orawls::nodemanager (
   } else {
     $replaceNodemanagerProperties = true
   }
+
+  $property_defaults = {
+    'log_limit'                          => '0',
+    'domains_dir_remote_sharing_enabled' => 'false',
+    'authentication_enabled'             => 'true',
+    'log_level'                          => 'INFO',
+    'domains_file_enabled'               => 'true',
+    'start_script_name'                  => 'startWebLogic.sh',
+    'native_version_enabled'             => 'true',
+    'log_to_stderr'                      => 'true',
+    'log_count'                          => '1',
+    'domain_registration_enabled'        => 'false',
+    'stop_script_enabled'                => 'true',
+    'quit_enabled'                       => 'false',
+    'log_append'                         => 'true',
+    'state_check_interval'               => '500',
+    'crash_recovery_enabled'             => 'true',
+    'start_script_enabled'               => 'true',
+    'log_formatter'                      => 'weblogic.nodemanager.server.LogFormatter',
+    'listen_backlog'                     => '50',
+  }
+
+  $properties_merged = merge($property_defaults, $properties)
 
   # nodemanager is part of the domain creation
   if ( $version == 1111 or $version == 1036 or $version == 1211 ){

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,10 @@
     {
       "name": "fiddyspence/sleep",
       "version_requirement": ">=1.2.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">=4.9.0"
     }
   ],
   "description": "Only for Linux & Solaris \nOracle WebLogic module optimized for Hiera and Puppet 3\nwls native types & providers like wls_machine, wls_server and wls_cluster\n\nbased on the wls module",

--- a/templates/nodemgr/nodemanager.properties.erb
+++ b/templates/nodemgr/nodemanager.properties.erb
@@ -3,27 +3,27 @@ NodeManagerHome=<%= @weblogic_home_dir %>/common/nodemanager
 JavaHome=<%= @jdk_home_dir %>
 ListenPort=<%= @nodemanager_port %>
 LogFile=<%= @nodeMgrLogDir %>
-LogLimit=0
+LogLimit=<%= @properties_merged['log_limit'] %>
 PropertiesVersion=10.3
-DomainsDirRemoteSharingEnabled=false
-AuthenticationEnabled=true
-LogLevel=INFO
-DomainsFileEnabled=true
-StartScriptName=startWebLogic.sh
+DomainsDirRemoteSharingEnabled=<%= @properties_merged['domains_dir_remote_sharing_enabled'] %>
+AuthenticationEnabled=<%= @properties_merged['authentication_enabled'] %>
+LogLevel=<%= @properties_merged['log_level'] %>
+DomainsFileEnabled=<%= @properties_merged['domains_file_enabled'] %>
+StartScriptName=<%= @properties_merged['start_script_name'] %>
 ListenAddress=<%= @nodemanager_address %>
-NativeVersionEnabled=true
-LogToStderr=true
+NativeVersionEnabled=<%= @properties_merged['native_version_enabled'] %>
+LogToStderr=<%= @properties_merged['log_to_stderr'] %>
 SecureListener=<%= @nodemanager_secure_listener %>
-LogCount=1
-DomainRegistrationEnabled=false
-StopScriptEnabled=true
-QuitEnabled=false
-LogAppend=true
-StateCheckInterval=500
-CrashRecoveryEnabled=true
-StartScriptEnabled=true
-LogFormatter=weblogic.nodemanager.server.LogFormatter
-ListenBacklog=50
+LogCount=<%= @properties_merged['log_count'] %>
+DomainRegistrationEnabled=<%= @properties_merged['domain_registration_enabled'] %>
+StopScriptEnabled=<%= @properties_merged['stop_script_enabled'] %>
+QuitEnabled=<%= @properties_merged['quit_enabled'] %>
+LogAppend=<%= @properties_merged['log_append'] %>
+StateCheckInterval=<%= @properties_merged['state_check_interval'] %>
+CrashRecoveryEnabled=<%= @properties_merged['crash_recovery_enabled'] %>
+StartScriptEnabled=<%= @properties_merged['start_script_enabled'] %>
+LogFormatter=<%= @properties_merged['log_formatter'] %>
+ListenBacklog=<%= @properties_merged['listen_backlog'] %>
 <% if @custom_identity == true %>
 KeyStores=CustomIdentityAndCustomTrust
 CustomIdentityKeyStoreFileName=<%= @custom_identity_keystore_filename %>

--- a/templates/nodemgr/nodemanager.properties_1212.erb
+++ b/templates/nodemgr/nodemanager.properties_1212.erb
@@ -1,28 +1,28 @@
 #Node manager properties
 DomainsFile=<%= @domains_dir %>/<%= @domain_name %>/nodemanager/nodemanager.domains
-LogLimit=0
+LogLimit=<%= @properties_merged['log_limit'] %>
 PropertiesVersion=12.1.2
-AuthenticationEnabled=true
+AuthenticationEnabled=<%= @properties_merged['authentication_enabled'] %>
 NodeManagerHome=<%= @domains_dir %>/<%= @domain_name %>/nodemanager
 JavaHome=<%= @jdk_home_dir %>
-LogLevel=INFO
-DomainsFileEnabled=true
-StartScriptName=startWebLogic.sh
+LogLevel=<%= @properties_merged['log_level'] %>
+DomainsFileEnabled=<%= @properties_merged['domains_file_enabled'] %>
+StartScriptName=<%= @properties_merged['start_script_name'] %>
 ListenAddress=<%= @nodemanager_address %>
-NativeVersionEnabled=true
+NativeVersionEnabled=<%= @properties_merged['native_version_enabled'] %>
 ListenPort=<%= @nodemanager_port %>
-LogToStderr=true
+LogToStderr=<%= @properties_merged['log_to_stderr'] %>
 SecureListener=<%= @nodemanager_secure_listener %>
-LogCount=1
-StopScriptEnabled=true
-QuitEnabled=false
-LogAppend=true
-StateCheckInterval=500
-CrashRecoveryEnabled=true
-StartScriptEnabled=true
+LogCount=<%= @properties_merged['log_count'] %>
+StopScriptEnabled=<%= @properties_merged['stop_script_enabled'] %>
+QuitEnabled=<%= @properties_merged['quit_enabled'] %>
+LogAppend=<%= @properties_merged['log_append'] %>
+StateCheckInterval=<%= @properties_merged['state_check_interval'] %>
+CrashRecoveryEnabled=<%= @properties_merged['crash_recovery_enabled'] %>
+StartScriptEnabled=<%= @properties_merged['start_script_enabled'] %>
 LogFile=<%= @nodeMgrLogDir %>
-LogFormatter=weblogic.nodemanager.server.LogFormatter
-ListenBacklog=50
+LogFormatter=<%= @properties_merged['log_formatter'] %>
+ListenBacklog=<%= @properties_merged['listen_backlog'] %>
 <% if @custom_identity == true %>
 KeyStores=CustomIdentityAndCustomTrust
 CustomIdentityKeyStoreFileName=<%= @custom_identity_keystore_filename %>

--- a/templates/nodemgr/nodemanager.properties_1213.erb
+++ b/templates/nodemgr/nodemanager.properties_1213.erb
@@ -1,28 +1,28 @@
 #Node manager properties
 DomainsFile=<%= @domains_dir %>/<%= @domain_name %>/nodemanager/nodemanager.domains
-LogLimit=0
+LogLimit=<%= @properties_merged['log_limit'] %>
 PropertiesVersion=12.1.3
-AuthenticationEnabled=true
+AuthenticationEnabled=<%= @properties_merged['authentication_enabled'] %>
 NodeManagerHome=<%= @domains_dir %>/<%= @domain_name %>/nodemanager
 JavaHome=<%= @jdk_home_dir %>
-LogLevel=INFO
-DomainsFileEnabled=true
-StartScriptName=startWebLogic.sh
+LogLevel=<%= @properties_merged['log_level'] %>
+DomainsFileEnabled=<%= @properties_merged['domains_file_enabled'] %>
+StartScriptName=<%= @properties_merged['start_script_name'] %>
 ListenAddress=<%= @nodemanager_address %>
-NativeVersionEnabled=true
+NativeVersionEnabled=<%= @properties_merged['native_version_enabled'] %>
 ListenPort=<%= @nodemanager_port %>
-LogToStderr=true
+LogToStderr=<%= @properties_merged['log_to_stderr'] %>
 SecureListener=<%= @nodemanager_secure_listener %>
-LogCount=1
-StopScriptEnabled=true
-QuitEnabled=false
-LogAppend=true
-StateCheckInterval=500
-CrashRecoveryEnabled=true
-StartScriptEnabled=true
+LogCount=<%= @properties_merged['log_count'] %>
+StopScriptEnabled=<%= @properties_merged['stop_script_enabled'] %>
+QuitEnabled=<%= @properties_merged['quit_enabled'] %>
+LogAppend=<%= @properties_merged['log_append'] %>
+StateCheckInterval=<%= @properties_merged['state_check_interval'] %>
+CrashRecoveryEnabled=<%= @properties_merged['crash_recovery_enabled'] %>
+StartScriptEnabled=<%= @properties_merged['start_script_enabled'] %>
 LogFile=<%= @nodeMgrLogDir %>
-LogFormatter=weblogic.nodemanager.server.LogFormatter
-ListenBacklog=50
+LogFormatter=<%= @properties_merged['log_formatter'] %>
+ListenBacklog=<%= @properties_merged['listen_backlog'] %>
 <% if @custom_identity == true %>
 KeyStores=CustomIdentityAndCustomTrust
 CustomIdentityKeyStoreFileName=<%= @custom_identity_keystore_filename %>


### PR DESCRIPTION
I added a `properties` parameters to the nodemanager defined type. This takes a hash of nodemanager properties that get applied to nodemanager.properties file (via the erb templates). All properties have defaults that get overridden by the properties parameter.

I needed to add puppetlabs' stdlib module to allow the hash merge. I hope that's ok.