### PR TITLE
wls_exec implementation

### DIFF
--- a/files/providers/wls_exec/execute.py.erb
+++ b/files/providers/wls_exec/execute.py.erb
@@ -1,0 +1,19 @@
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+try:
+
+  puppet = open("/tmp/wlstScript.out", "w")
+  print >>puppet, "output"
+
+  <%= statement %>
+
+  puppet.close()
+  print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+  print "Unexpected error:", sys.exc_info()[0]
+  undo('true','y')
+  stopEdit('y')
+  print "~~~~COMMAND FAILED~~~~"
+  raise

--- a/lib/puppet/provider/wls_exec/simple.rb
+++ b/lib/puppet/provider/wls_exec/simple.rb
@@ -1,0 +1,9 @@
+require 'easy_type'
+require 'utils/wls_access'
+
+Puppet::Type.type(:wls_domain).provide(:simple) do
+  include EasyType::Provider
+
+  desc 'Manage all the WebLogic domain options via regular WLST'
+  mk_resource_methods
+end

--- a/lib/puppet/provider/wls_exec/simple.rb
+++ b/lib/puppet/provider/wls_exec/simple.rb
@@ -1,9 +1,0 @@
-require 'easy_type'
-require 'utils/wls_access'
-
-Puppet::Type.type(:wls_domain).provide(:simple) do
-  include EasyType::Provider
-
-  desc 'Manage all the WebLogic domain options via regular WLST'
-  mk_resource_methods
-end

--- a/lib/puppet/provider/wls_exec/wlst.rb
+++ b/lib/puppet/provider/wls_exec/wlst.rb
@@ -1,0 +1,42 @@
+require 'easy_type/helpers'
+require 'fileutils'
+require File.dirname(__FILE__) + '/../../../orawls_core'
+
+Puppet::Type.type(:wls_exec).provide(:sqlplus) do
+  include EasyType::Helpers
+  include EasyType::Template
+  include Utils::WlsAccess
+
+  mk_resource_methods
+
+  def flush
+    return if resource[:refreshonly] == :true
+    execute
+  end
+
+  def execute
+    cwd        = resource[:cwd]
+    statement  = resource[:statement]
+    #
+    # If the statement start's with a @, it is a script. The content will be executed
+    #
+    if is_script?(statement)
+      file_name = statement.split('@').last
+      fail "File #{file_name} doesn't exsist. " unless File.exists?(file_name)
+      statement = File.read(file_name)
+    end
+
+    fail "Working directory '#{cwd}' does not exist" if cwd && !File.directory?(cwd)
+    FileUtils.cd(resource[:cwd]) if resource[:cwd]
+    environment = { 'action' => 'execute', 'type' => 'wls_exec' }
+    output = wlst template('puppet:///modules/orawls/providers/wls_exec/execute.py.erb', binding), environment
+    Puppet.debug(output) if resource.logoutput == :true
+  end
+
+  private
+
+  def is_script?(statement)
+    statement.chars.first == '@'
+  end
+
+end

--- a/lib/puppet/type/wls_exec.rb
+++ b/lib/puppet/type/wls_exec.rb
@@ -1,43 +1,29 @@
 require File.dirname(__FILE__) + '/../../orawls_core'
 
-
 module Puppet
   Type.newtype(:wls_exec) do
     include EasyType
     include Utils::WlsAccess
     extend Utils::TitleParser
 
-    desc 'This resource allows you to manage a cluster in an WebLogic domain.'
+    desc 'This resource allows you to execute a wlst command or script in the context.'
 
-    ensurable
-
-    set_command(:wlst)
-
-    to_get_raw_resources do
+    add_title_attributes(:statement) do
+      /^((\w+\/)?(.*)?)$/
     end
 
-    on_create do | command_builder |
-    end
-
-    on_modify do | command_builder |
-    end
-
-    on_destroy do | command_builder |
+    def refresh
+      provider.execute
     end
 
     parameter :domain
     parameter :name
-    parameter :safagent_name
+    property  :statement
     parameter :timeout
-    property :servicetype
-    property :persistentstore
-    property :persistentstoretype
-    property :target
-    property :targettype
-
-    add_title_attributes(:safagent_name) do
-      /^((.*\/)?(.*)?)$/
-    end
+    parameter :cwd
+    parameter :logoutput
+    parameter :unless
+    parameter :refreshonly
 
   end
 end

--- a/lib/puppet/type/wls_exec.rb
+++ b/lib/puppet/type/wls_exec.rb
@@ -1,0 +1,43 @@
+require File.dirname(__FILE__) + '/../../orawls_core'
+
+
+module Puppet
+  Type.newtype(:wls_exec) do
+    include EasyType
+    include Utils::WlsAccess
+    extend Utils::TitleParser
+
+    desc 'This resource allows you to manage a cluster in an WebLogic domain.'
+
+    ensurable
+
+    set_command(:wlst)
+
+    to_get_raw_resources do
+    end
+
+    on_create do | command_builder |
+    end
+
+    on_modify do | command_builder |
+    end
+
+    on_destroy do | command_builder |
+    end
+
+    parameter :domain
+    parameter :name
+    parameter :safagent_name
+    parameter :timeout
+    property :servicetype
+    property :persistentstore
+    property :persistentstoretype
+    property :target
+    property :targettype
+
+    add_title_attributes(:safagent_name) do
+      /^((.*\/)?(.*)?)$/
+    end
+
+  end
+end

--- a/lib/puppet/type/wls_exec/cwd.rb
+++ b/lib/puppet/type/wls_exec/cwd.rb
@@ -1,0 +1,8 @@
+
+newparam(:cwd) do
+
+  desc <<-EOD
+  The default directory from where the scripts will be run. If not specfied, this will be /tmp. 
+  EOD
+
+end

--- a/lib/puppet/type/wls_exec/logoutput.rb
+++ b/lib/puppet/type/wls_exec/logoutput.rb
@@ -1,0 +1,13 @@
+newparam(:logoutput) do
+  desc <<-EOD
+  Whether to log command output in addition to logging the
+  exit code.  Defaults to `on_failure`, which only logs the output
+  when the command has an exit code that does not match any value
+  specified by the `returns` attribute. As with any resource type,
+  the log level can be controlled with the `loglevel` metaparameter."
+  EOD
+
+  defaultto :on_failure
+
+  newvalues(:true, :false, :on_failure)
+end

--- a/lib/puppet/type/wls_exec/refreshonly.rb
+++ b/lib/puppet/type/wls_exec/refreshonly.rb
@@ -1,0 +1,14 @@
+newparam(:refreshonly) do
+  desc <<-'EOT'
+    The command should only be run as a
+    refresh mechanism for when a dependent object is changed.  It only
+    makes sense to use this option when this command depends on some
+    other object; it is useful for triggering an action:
+
+    Note that only `subscribe` and `notify` can trigger actions, not `require`,
+    so it only makes sense to use `refreshonly` with `subscribe` or `notify`.
+  EOT
+
+  newvalues(:true, :false)
+
+end

--- a/lib/puppet/type/wls_exec/statement.rb
+++ b/lib/puppet/type/wls_exec/statement.rb
@@ -1,0 +1,39 @@
+newproperty(:statement) do
+  include Utils::WlsAccess
+  include ::EasyType::Helpers
+  include ::EasyType::Template
+
+  desc "The wlst statement or script to execute"
+
+  #
+  # Let the insync? check for the parameter unless and the refreshonly
+  #
+  def insync?(to)
+    if resource[:refreshonly] != :true
+      resource[:unless] ? unless_value? : false
+    else
+      true
+    end
+  end
+
+  private
+
+  def unless_value?
+    domain = resource[:domain]
+    statement = resource[:unless]
+    if is_script?(statement)
+      file_name = statement.split('@').last
+      fail "File #{file_name} doesn't exist. " unless File.exists?(file_name)
+      statement = File.read(file_name)
+    end
+    environment = { 'action' => 'index', 'type' => 'wls_exec' }
+    output = wlst template('puppet:///modules/orawls/providers/wls_exec/execute.py.erb', binding), environment
+    !output.empty?
+  end
+
+  def is_script?(statement)
+    statement.chars.first == '@'
+  end
+
+
+end

--- a/lib/puppet/type/wls_exec/unless.rb
+++ b/lib/puppet/type/wls_exec/unless.rb
@@ -1,0 +1,15 @@
+
+newparam(:unless) do
+
+  desc <<-EOD
+  A statement to determine if the wls_exec must execute or not.
+
+  If the statement returns something,the wls_exec is **NOT** executed. If the statement returns nothing,
+  the specified wls_exec statement **IS** executed.
+
+  The unless clause **must** be a valid WLST statement. An error in the query will result in
+  a failure of the apply statement.
+
+  EOD
+
+end


### PR DESCRIPTION
This PR allows you easy access to wls from Puppet. Just like `exec` and `ora_exec`, it allows you to execute statements or scripts. This is useful when you need to do very specific stuff that is not (yet) supported by the custom types.

```puppet
wls_exec{"domain\print 'hallo'":}
```

execute the `print "hallo"`  statement in the logged in wlst context. Obvious, this doesn't really help. But you can also use other more helpfull statements.

You can also execute scripts.

```puppet
wls_exec{"domain\@tmp/create_wls_resource.wlst":}
```

This will execute the content of the specified script.

You can also execute a check before executing the real content. This is the way to make idempotent Puppet statements

```puppet
wls_exec{"domain\@tmp/create_wls_resource.wlst":
  unless => '@/tmp/check_wls_resource.wlst'
}
```

If the `/tmp/check_wlst_resource.wlst`  script returns something to the channel opened with the name `puppet` , Puppet will not do anything.

`check_wlst_resource.wlst`

```python
print >>puppet, "the resource exists."
```

You can also use it in refresh only mode.

```puppet
file{'/a_file':
  ensure => present,
} ~>
wls_exec{"domain\@tmp/create_wls_resource.wlst":
  refreshonly => true,
}
```

Just like the original `exec`  you can see the output:

```puppet
wls_exec{"domain\@tmp/create_wls_resource.wlst":
  refreshonly => true,
  logoutput => on_error
}


wls_exec{"domain\@tmp/create_wls_resource.wlst":
  refreshonly => true,
  logoutput   => true,
}

```

