### PR TITLE
Improve wls_server 'arguments' property

### DIFF
--- a/files/providers/wls_server/create.py.erb
+++ b/files/providers/wls_server/create.py.erb
@@ -3,7 +3,7 @@ real_domain='<%= domain %>'
 
 name          = '<%= server_name %>'
 classpath     = '<%= classpath %>'
-arguments     = '''<%= arguments %>'''
+arguments     = '<%= arguments.join(' ') %>'
 machineName   = '<%= machine %>'
 bea_home      = '<%= bea_home %>'
 

--- a/files/providers/wls_server/modify.py.erb
+++ b/files/providers/wls_server/modify.py.erb
@@ -10,7 +10,7 @@ manage_machine        = False
 name          = '<%= server_name %>'
 
 <% unless arguments.nil? %>
-arguments        = '''<%= arguments %>'''
+arguments        = '<%= arguments.join(' ') %>'
 manage_arguments = True
 <% end %>
 

--- a/lib/puppet/type/wls_server/arguments.rb
+++ b/lib/puppet/type/wls_server/arguments.rb
@@ -1,24 +1,45 @@
-newproperty(:arguments) do
+newproperty(:arguments, :array_matching => :all) do
   include EasyType
 
-  desc 'The server arguments of the server'
+  desc 'The server sttart arguments of the server.
+    Can be specified as an array or a space separated string'
+  #or both...
+  #The following should also work
+  #arguments => ['arg1 arg2','arg3','arg4 arg5']
+  #and be idempotent with 'arg4 arg3 arg1 arg2 arg5' and [arg1,arg4,arg2,'arg3 arg5'] etc
 
   to_translate_to_resource do | raw_resource|
-    return '' if raw_resource['arguments'].nil?
-    raw_resource['arguments']
+    return [] if raw_resource['arguments'].nil?
+    raw_resource['arguments'].split(/\s/)
   end
 
-  def should=(values)
-    values = values.flatten.join("\n") if values.is_a?(Array)
-    @should = values
+  munge do |value|
+    if value.is_a?(String)
+      value = value.split(/\s/)
+    else
+      raise Puppet::Error "Invalid server start argument: #{value.inspect}"
+    end
   end
 
   def should
     return nil unless defined?(@should)
-    @should
+    #Return simple array out of possibly nested one.  eg [['bar'],['foo','foobar']] into ['bar','foo','foobar']
+    @should.join(' ').split(' ')
+  end
+
+  def change_to_s(current, desire)
+    message = ''
+    unless ((current-desire).inspect) == '[]'
+      message << "removing #{(current-desire).inspect} "
+    end
+    unless ((desire-current).inspect) == '[]'
+      message << "adding #{(desire-current).inspect} "
+    end
+    message
   end
 
   def insync?(is)
-    is == @should
+    is = [] if is == :absent or is.nil?
+    is.sort == should.sort
   end
 end


### PR DESCRIPTION
The original code just took arguments as a simple string.  The code was then improved to
accept arrays too.  Arrays were flattened to newline separated strings before being passed
to the template.

A few issues with this.
Weblogic actually preferred server arguments as space separated strings.
In weblogic 12.1, if you use the web interface to enter arguments one per line, they get
converted to space separated when you hit 'save'.

If an array was used to set arguments, output from puppet resource was as the newline separated
string.  This looked a bit nasty.  It would have been much nicer to have puppet return an array
of arguments no matter how they were created.

The order of the arguments would be taken into account when comparing is and should
values.  Things that should probably have been idempotent weren't.

This commit retains the ability to specify the arguments as either a string or an
array.  But now, order is not important.
['arg1','arg2'] is considered the same as 'arg2 arg1'
If puppet does need to update the property, the puppet output is customised to say
which arguments (if any) are being removed, and which are being added.