### PR TITLE
Running the wls_exec unless statement only on specfied domain

### DIFF
--- a/lib/puppet/type/wls_exec/statement.rb
+++ b/lib/puppet/type/wls_exec/statement.rb
@@ -26,7 +26,7 @@ newproperty(:statement) do
       fail "File #{file_name} doesn't exist. " unless File.exists?(file_name)
       statement = File.read(file_name)
     end
-    environment = { 'action' => 'index', 'type' => 'wls_exec' }
+    environment = { 'action' => 'execute', 'type' => 'wls_exec' }
     output = wlst template('puppet:///modules/orawls/providers/wls_exec/execute.py.erb', binding), environment
     !output.empty?
   end


### PR DESCRIPTION
This PR fixes an issue when using `wls_exec` on a multidomain setup. It would run the unless statement on all domains. This PR fixes this. I have refactered the wls_access code a little bit to allow this