### PR TITLE
Fix setting constrained_candidate_servers for wls_migratable_target t…

### DIFF
--- a/files/providers/wls_migratable_target/create.py.erb
+++ b/files/providers/wls_migratable_target/create.py.erb
@@ -8,7 +8,7 @@ cluster                          = '<%= cluster %>'
 number_of_restart_attempts       = <%= number_of_restart_attempts %>
 seconds_between_restarts         = <%= seconds_between_restarts %>
 
-<% if @constrained_candidate_servers %>
+<% if constrained_candidate_servers %>
 constrained_candidate_servers    = [<%= constrained_candidate_servers.map{ |server| "'#{server}'" }.join(',') %>]
 <% else %>
 constrained_candidate_servers    = []

--- a/files/providers/wls_migratable_target/modify.py.erb
+++ b/files/providers/wls_migratable_target/modify.py.erb
@@ -8,7 +8,7 @@ cluster                          = '<%= cluster %>'
 number_of_restart_attempts       = <%= number_of_restart_attempts %>
 seconds_between_restarts         = <%= seconds_between_restarts %>
 
-<% if @constrained_candidate_servers %>
+<% if constrained_candidate_servers %>
 constrained_candidate_servers    = [<%= constrained_candidate_servers.map{ |server| "'#{server}'" }.join(',') %>]
 <% else %>
 constrained_candidate_servers    = []

--- a/files/providers/wls_saf_imported_destination_object/index.py.erb
+++ b/files/providers/wls_saf_imported_destination_object/index.py.erb
@@ -15,7 +15,7 @@ def object(token,token2,token3,location,type):
     localjndiname     = cmo.getLocalJNDIName()
     unitoforder       = cmo.getUnitOfOrderRouting()
 
-    timeToLiveDefault = cmo.getTimeToLiveDefault()
+    timeToLiveDefault = str(cmo.getTimeToLiveDefault())
     if not (timeToLiveDefault):
       useSAFTimeToLiveDefault = '0'
     else:


### PR DESCRIPTION
A couple of minor bugfixes:

1) Creating constrained_candidate_servers for the wls_migratable_target type wasn't working (conditional in erb template always fell through to else block).

2) Setting timetolivedefault to 0 explicitly didn't work. The `if text` conditional in the `quote()` method would evaluate to false when text is 0 (0 is false in Ruby). Typecasting value to string fixes problem.