### PR TITLE
Allow escaping the semicolon in the properties of a resource adapter.

### DIFF
--- a/templates/adapter_plans/createResourceAdapterEntry.py.erb
+++ b/templates/adapter_plans/createResourceAdapterEntry.py.erb
@@ -47,7 +47,14 @@ def main():
       myPlan.save();
 
       pList = propertyName.split(';')
-      vList = cfName.split(';')
+
+      encodedValues = cfName.replace('\;','#') # Replace escaped semicolons for a dash
+      encodedList = encodedValues.split(';')
+
+      vList = []
+      for valueString in encodedList:
+        vList.append(valueString.replace('#', ';'))
+
       if len(pList) == len(vList):
         i = 0
         for p in pList:


### PR DESCRIPTION
For example:

```pupet
  orawls::resourceadapter { 'JmsAdapter_AMV':
    adapter_name           => 'JmsAdapter',
    adapter_path           => "/opt/oracle/soat/middleware/soa/soa/connectors/JmsAdapter.rar",
    adapter_plan_dir       => "${plan_dir}",
    adapter_plan           => 'JmsAdapter.xml',
    adapter_entry          => 'eis/MQChannel/AMV',
    adapter_entry_property => 'ConnectionFactoryLocation;FactoryProperties;IsTransacted;Username',
    adapter_entry_value    => 'com.ibm.mq.jms.MQXAQueueConnectionFactory;QueueManager=QUEMGR1\;TransportType=1\;HostName=10.10.10.10\;Port=1414\;Channel=AXA.QMGR\;ThirdPartyJMSProvider=true;true;mqm',
  }
```