### PR TITLE
Fix creating wls_server with no arguments

### DIFF
--- a/files/providers/wls_server/create.py.erb
+++ b/files/providers/wls_server/create.py.erb
@@ -3,7 +3,9 @@ real_domain='<%= domain %>'
 
 name          = '<%= server_name %>'
 classpath     = '<%= classpath %>'
+<% unless arguments.nil? %>
 arguments     = '<%= arguments.join(' ') %>'
+<% end %>
 machineName   = '<%= machine %>'
 bea_home      = '<%= bea_home %>'
 


### PR DESCRIPTION
Check arguments isn't nil before calling 'join' on it.
Fixes following error when creating wls_server...

```
puppet apply -e 'wls_server{"default/test": ensure => present, machine => "LocalMachine"}'

'Error: /Stage[main]/Main/Wls_server[default/test]/ensure: change from absent to present failed: Could not set 'present' on ensure: undefined method `join' for nil:NilClass in 1'
```