### PR TITLE
Nodemanager fails to start first time if param log_dir is used and directory doesn't exist

### DIFF
--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -73,6 +73,7 @@ define orawls::nodemanager (
           owner   => $os_user,
           group   => $os_group,
           require => Exec["create ${log_dir} directory"],
+          before  => Exec["startNodemanager ${title}"],
         }
       }
       $nodeMgrLogDir = "${log_dir}/nodemanager.log"


### PR DESCRIPTION
If using parameter log_dir and the directory doesn't exist nodemanager fails to start. The log_dir is  created but it needs to be before the exec to start nodemanager. I also think that the exec may need to change so any error is captured, but at the minute it fails silently. A second puppet run resolves the issue because the directories are created on the first run. Adding a before to the log_dir creation resolves the issue. 