### PR TITLE
Add wrapdatatypes property

### DIFF
--- a/files/providers/wls_datasource/create.py.erb
+++ b/files/providers/wls_datasource/create.py.erb
@@ -28,6 +28,7 @@ rowprefetchenabled                      = '<%= rowprefetchenabled %>'
 rowprefetchsize                         = '<%= rowprefetchsize %>'
 initsql                                 = "<%= (initsql||'').gsub('"','\"') %>"
 shrinkfrequencyseconds                  = '<%= shrinkfrequencyseconds %>'
+wrapdatatypes                           = '<%= wrapdatatypes %>'
 
 edit()
 startEdit()
@@ -86,6 +87,11 @@ try:
 
     if shrinkfrequencyseconds:
       set('ShrinkFrequencySeconds', int(shrinkfrequencyseconds))
+
+    if wrapdatatypes == '1':
+      set('WrapTypes', 'true')
+    else:
+      set('WrapTypes', 'false')
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
@@ -163,7 +169,6 @@ try:
             targetList.append( ObjectName('com.bea:Name=' + tagged[i] + ',Type='+taggedtype[i]) )
 
     else:
-
         for i in range(len(targets)):
           print "target "+targets[i] + " " + targettypes[i]
           targetList.append( ObjectName('com.bea:Name=' + targets[i] + ',Type='+targettypes[i]) )

--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -9,7 +9,7 @@ def quote(text):
 m = ls('/JDBCSystemResources',returnMap='true')
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;target;targettype;drivername;jndinames;url;usexa;xaproperties;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist;mincapacity;statementcachesize;testconnectionsonreserve;secondstotrustidlepoolconnection;testfrequency;connectioncreationretryfrequency;rowprefetchenabled;rowprefetchsize;initsql;shrinkfrequencyseconds"
+print >>f, "name;target;targettype;drivername;jndinames;url;usexa;xaproperties;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist;mincapacity;statementcachesize;testconnectionsonreserve;secondstotrustidlepoolconnection;testfrequency;connectioncreationretryfrequency;rowprefetchenabled;rowprefetchsize;initsql;shrinkfrequencyseconds;wrapdatatypes"
 for token in m:
     print '___'+token+'___'
     cd('/JDBCSystemResources/'+token + '/JDBCResource/' + token)
@@ -43,6 +43,11 @@ for token in m:
         testfrequency = get('TestFrequencySeconds')
         connectioncreationretryfrequency = str(get('ConnectionCreationRetryFrequencySeconds'))
         initsql = str(get('InitSql'))
+
+        if get('WrapTypes'):
+          wrapdatatypes = '1'
+        else:
+          wrapdatatypes = '0'
 
         cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDataSourceParams/' + token )
         jndinames = get('JNDINames')
@@ -133,10 +138,10 @@ for token in m:
                 missing = 1
 
         if not tagged:
-            print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
         elif missing == 0:
-            print >>f, ";".join(map(quote, [domain+'/'+token,'inherited','inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,'inherited','inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
         else:
-            print >>f, ";".join(map(quote, [domain+'/'+token,'not_inherited','not_inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,'not_inherited','not_inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_datasource/modify.py.erb
+++ b/files/providers/wls_datasource/modify.py.erb
@@ -27,6 +27,7 @@ rowprefetchenabled                      = '<%= rowprefetchenabled %>'
 rowprefetchsize                         = '<%= rowprefetchsize %>'
 initsql                                 = "<%= (initsql||'').gsub('"','\"') %>"
 shrinkfrequencyseconds                  = '<%= shrinkfrequencyseconds %>'
+wrapdatatypes                           = '<%= wrapdatatypes %>'
 
 edit()
 startEdit()
@@ -84,6 +85,10 @@ try:
     if shrinkfrequencyseconds:
       set('ShrinkFrequencySeconds', int(shrinkfrequencyseconds))
 
+    if wrapdatatypes == '1':
+      set('WrapTypes', 'true')
+    else:
+      set('WrapTypes', 'false')
 
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
@@ -177,7 +182,6 @@ try:
             targetList.append( ObjectName('com.bea:Name=' + tagged[i] + ',Type='+taggedtype[i]) )
 
     else:
-
         for i in range(len(targets)):
           print "target "+targets[i] + " " + targettypes[i]
           targetList.append( ObjectName('com.bea:Name=' + targets[i] + ',Type='+targettypes[i]) )

--- a/lib/puppet/type/shared/wrapdatatypes.rb
+++ b/lib/puppet/type/shared/wrapdatatypes.rb
@@ -1,0 +1,12 @@
+newproperty(:wrapdatatypes) do
+  include EasyType
+
+  desc 'Should weblogic wrap data types.'
+  newvalues('1', '0')
+  defaultto '1'
+
+  to_translate_to_resource do |raw_resource|
+    raw_resource['wrapdatatypes']
+  end
+
+end

--- a/lib/puppet/type/wls_datasource.rb
+++ b/lib/puppet/type/wls_datasource.rb
@@ -66,6 +66,7 @@ module Puppet
     property :rowprefetchsize
     property :initsql
     property :shrinkfrequencyseconds
+    property :wrapdatatypes
 
     add_title_attributes(:datasource_name) do
       /^((.*\/)?(.*)?)$/


### PR DESCRIPTION
Add property to manage connection pool advanced switch 'Wrap Data Types'.
Defaults to 'on' if not specified same as weblogic.

There are no spec tests for this property.
I have tested deployments with wrapdatatypes set on, off and not specified.