### PR TITLE
fix wls_rcu error handling

### DIFF
--- a/lib/puppet/provider/wls_rcu/wls_rcu.rb
+++ b/lib/puppet/provider/wls_rcu/wls_rcu.rb
@@ -48,7 +48,7 @@ Puppet::Type.type(:wls_rcu).provide(:wls_rcu) do
     su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
 
     rcu_output = `su #{su_shell} - #{user} -c 'export TZ=GMT;#{oraclehome}/common/bin/wlst.sh #{checkscript} #{jdbcurl} #{syspassword} #{prefix} #{sysuser}'`
-    fail ArgumentError, "Error executing puppet code, #{output}" if $CHILD_STATUS != 0
+    fail ArgumentError, "Error executing puppet code, #{rcu_output}" if $CHILD_STATUS != 0
     Puppet.info "RCU check result: #{rcu_output}"
     rcu_output.each_line do |li|
       unless li.nil?


### PR DESCRIPTION
was getting this error originally when this breaks down (in my case a java_home issue).  To duplicate point wlst.sh to an invalid Java_Home and try rcu create.  Errors are descriptive after this change, unlike the below:

Orawls::Domain[wlsdomain cl8625]/Orawls::Utils::Rcu[RCU_12c wlsdomain cl8625]/Wls_rcu[SOA12POC]) Could not evaluate: undefined local variable or method `output' for #<Puppet::Type::Wls_rcu::ProviderWls_rcu:0x7fe23a4c3f28>