### PR TITLE
Fix easy_type load issues in specific situation

### DIFF
--- a/lib/orawls_core.rb
+++ b/lib/orawls_core.rb
@@ -1,6 +1,8 @@
 require 'pathname'
-$:.unshift(Pathname.new(__FILE__).dirname)
-$:.unshift(Pathname.new(__FILE__).dirname.parent.parent + 'easy_type' + 'lib')
+#$:.unshift(Pathname.new(__FILE__).dirname)
+#$:.unshift(Pathname.new(__FILE__).dirname.parent.parent + 'easy_type' + 'lib')
+$:.unshift File.dirname(__FILE__)
+$:.unshift File.join(File.dirname(__FILE__), '../../easy_type/lib')
 require 'easy_type'
 require 'utils/wls_access'
 require 'utils/settings'


### PR DESCRIPTION
This commit fixes the load of easy_type in specific situations. Due to
the ways the Puppet masters are setup at our environment, the catalogue
failed to compile as it was unable to find easy_type. Even though it was
present and working fine in a local Vagrant box, we were puzzled why
this did not work.

Eventually, we involved someone from the Puppetlabs module team, who
proposed this fix. I discussed if this could be committed back upstream
/ was backwards compatible and he confirmed.

Long story short, this commit fixes the way easy_type is put in the
Ruby load path and fixes a long outstanding production issue in our
environment.