### PR TITLE
Add support for provider_specific attributes on wls_authentication_provider

### DIFF
--- a/files/providers/wls_authentication_provider/create.py.erb
+++ b/files/providers/wls_authentication_provider/create.py.erb
@@ -106,7 +106,14 @@ try:
             # Apply the new order
             set('AuthenticationProviders', ap)
 
-
+    #
+    # Set resource specific values
+    #
+    cd('AuthenticationProviders/'+name)
+<% provider_specific.each do | name, value | -%>
+    print 'Setting property <%= name -%> to <%= value -%>'
+    set('<%= name -%>','<%= value -%>')
+<% end -%>
 
     print "done"
     save()

--- a/files/providers/wls_authentication_provider/fetch.py.erb
+++ b/files/providers/wls_authentication_provider/fetch.py.erb
@@ -1,0 +1,37 @@
+real_domain='<%= current_resource.domain %>'
+
+def quote(text):
+    if text or text == '':
+        return "\"" + str(text).replace("\"", "\"\"") + "\""
+    else:
+        return ""
+
+name            = '<%= current_resource.authentication_provider_name %>'
+attribute_names = <%= current_resource.provider_specific.keys %>
+realmName       = cmo.getSecurityConfiguration().getDefaultRealm()
+cd('/')
+path            = getPath(realmName)
+cd(path + '/AuthenticationProviders/' + name)
+
+try:
+  puppet = open("/tmp/wlstScript.out", "w")
+  print >>puppet, ';'.join(attribute_names)
+  #
+  # Get all specified values
+  #
+<% current_resource.provider_specific.keys.each do | key | -%>
+  <%= key -%> = str(get('<%= key -%>'))
+  print '<%= key -%> is ' + <%= key %>
+<% end -%>
+  #
+  # All values fetched
+  #
+  print >>puppet, ';'.join(map(quote,[<%= current_resource.provider_specific.keys.join(',') -%>]))
+  puppet.close()
+  print "~~~~COMMAND SUCCESFULL~~~~"
+
+
+except:
+  print "Unexpected error:", sys.exc_info()[0]
+  print "~~~~COMMAND FAILED~~~~"
+  raise

--- a/files/providers/wls_authentication_provider/modify.py.erb
+++ b/files/providers/wls_authentication_provider/modify.py.erb
@@ -3,9 +3,9 @@ real_domain='<%= domain %>'
 
 
 
-name                      = '<%= authentication_provider_name %>'
-control_flag              = '<%= control_flag %>'
-order                     = '<%= order %>'
+name            = '<%= authentication_provider_name %>'
+control_flag    = '<%= control_flag %>'
+order           = '<%= order %>'
 
 edit()
 startEdit()
@@ -18,6 +18,15 @@ try:
     cd(path)
 
     cd('AuthenticationProviders/'+name)
+
+    #
+    # Set resource specific values
+    #
+<% provider_specific.each do | name, value | -%>
+    print 'Setting property <%= name -%> to <%= value -%>'
+    set('<%= name -%>','<%= value -%>')
+<% end -%>
+
     if control_flag:
         cmo.setControlFlag(control_flag)
 

--- a/lib/puppet/provider/wls_authentication_provider/prefetching.rb
+++ b/lib/puppet/provider/wls_authentication_provider/prefetching.rb
@@ -1,0 +1,28 @@
+require 'easy_type'
+require 'utils/wls_access'
+
+Puppet::Type.type(:wls_authentication_provider).provide(:prefetching) do
+  include EasyType::Provider
+  include EasyType::Template
+  include EasyType::Helpers
+  include Utils::WlsAccess
+
+  desc 'Manage wls_authentication_providers'
+
+  mk_resource_methods
+
+  def self.prefetch(resources)
+    objects = instances
+    resources.keys.each do |name|
+      current_resource = resources[name]
+      provider = instances.find { |i| i.name == name }
+      if provider
+        current_resource.provider = provider
+        environment = { 'action' => 'execute', 'type' => :wls_authentication_provider }
+        values = wlst template('puppet:///modules/orawls/providers/wls_authentication_provider/fetch.py.erb', binding), environment
+        provider.property_hash[:provider_specific] = values.first
+      end
+    end
+  end
+
+end

--- a/lib/puppet/provider/wls_authentication_provider/simple.rb
+++ b/lib/puppet/provider/wls_authentication_provider/simple.rb
@@ -1,9 +1,0 @@
-require 'easy_type'
-require 'utils/wls_access'
-
-Puppet::Type.type(:wls_authentication_provider).provide(:simple) do
-  include EasyType::Provider
-
-  desc 'Manage authentication providers in an WebLogic domain via regular WLST'
-  mk_resource_methods
-end

--- a/lib/puppet/type/wls_authentication_provider.rb
+++ b/lib/puppet/type/wls_authentication_provider.rb
@@ -8,7 +8,27 @@ module Puppet
     include Utils::WlsAccess
     extend Utils::TitleParser
 
-    desc 'This resource allows you to manage authentication providers in an WebLogic domain.'
+    desc <<-EOD
+      This resource allows you to manage authentication providers in an WebLogic domain.
+
+      Here is an example:
+
+          wls_authentication_provider { 'domain/MyLDAPAuthenticator':
+            control_flag       => 'REQUIRED',
+            order              => '0',
+            providerclassname  => 'weblogic.security.providers.authentication.LDAPAuthenticator',
+            provider_specific  => {
+              'ResultsTimeLimit' => 300,
+            },
+          }
+
+      **ATTENTION:**
+
+      After the creation or modification of a wls_authentication_provider you'll need a restart from the 
+      Admin server. If you don't restart the server, the changes will not be applied. In some cases this means
+      that Puppet will try to re-create the wls_authentication_provider and will produce an WLST error.
+
+    EOD
 
     ensurable
 
@@ -45,6 +65,7 @@ module Puppet
     parameter :attributes
     parameter :attributesvalues
     parameter :order
+    property  :provider_specific
 
     add_title_attributes(:authentication_provider_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_authentication_provider/attributes.rb
+++ b/lib/puppet/type/wls_authentication_provider/attributes.rb
@@ -3,4 +3,9 @@ newparam(:attributes) do
 
   desc 'The extra authentication provider properties'
 
+  validate do | value|
+    Puppet.deprecation_warning("The attributes parameter on wls_authentication_provide is deprecated. Use the provider_specific property now.")
+    value
+  end
+
 end

--- a/lib/puppet/type/wls_authentication_provider/attributesvalues.rb
+++ b/lib/puppet/type/wls_authentication_provider/attributesvalues.rb
@@ -3,4 +3,9 @@ newparam(:attributesvalues) do
 
   desc 'The extra authentication provider property values'
 
+  validate do | value|
+    Puppet.deprecation_warning("The attributesvalues parameter on wls_authentication_provider is deprecated. Use the provider_specific property now.")
+    value
+  end
+
 end

--- a/lib/puppet/type/wls_authentication_provider/provider_specific.rb
+++ b/lib/puppet/type/wls_authentication_provider/provider_specific.rb
@@ -1,0 +1,68 @@
+newproperty(:provider_specific) do
+  include EasyType
+
+  desc <<-EOD
+    The provider specific properties.
+
+    This value is a Hash that contains key's and values. Here is an example on how to use this:
+
+        wls_authentication_provider { 'domain/MyLDAPAuthenticator':
+          ...
+          provider_specific   => {
+            'ResultsTimeLimit' => 300,
+            'SSLEnabled'       => 0,
+            'Host'             => 'ldap.enterprisemodules.com',
+            'ConnectTimeout'   => '5000',
+          },
+          providerclassname  => 'weblogic.security.providers.authentication.LDAPAuthenticator',
+        }
+
+      In this example the `ResultsTimeLimit`, `SSLEnabled`, `Host` and `ConnectTimeout` are the 
+      provider-specific properties for the `weblogic.security.providers.authentication.LDAPAuthenticator` 
+      class. In this example, we mix integer values and quoted integer values. It doesn't matter. Internally 
+        all values are quoted and converted to their right representation.
+
+      For the logical value `SSLEnabled`, you must use `0` for false and `1` for true. When you use the values
+       `false` or `true`, the changes are not idempotent.
+
+      When you specify a key value that the provider doesn't understand or a value that is invalid for the
+      specific property, the puppet type will fail with the error 
+
+      `Error: Failed to apply catalog: command in daemon failed.`
+
+      **ATTENTION:**
+
+      Most of the properties from the wls_authentication_provider need a restart from the Admin server. 
+      If you don't restart the server, the changes will not be applied, and Puppet will redo them. 
+
+  EOD
+
+  defaultto({})
+
+  def insync?(is)
+    is.to_a.sort == should.to_a.sort
+  end
+
+  validate do | value|
+    fail "should be a Hash value" unless value.is_a?(Hash)
+  end
+
+  #
+  # Make sure the key and the values in the hashes are strings
+  #
+  munge do | value_hash|
+    value_hash.each do | key, value|
+      value_hash[key.to_s] = value.to_s
+    end
+    value_hash
+  end
+
+  def change_to_s(from, to)
+    return_value = []
+    from.keys.each do | property|
+      return_value << "property #{property} from #{from[property]} to #{to[property]}" if to[property] != from[property]
+    end
+    "Changed #{return_value.join(' and ')}."
+  end
+
+end


### PR DESCRIPTION
This PR provides the `provider_specific`  propery on `wls_authentication_provider`. Using this property, you can manage the attributes from any type of authentication_provider. This PR also add's deprecation messages to `attributes` and `attributesvalues`.