### PR TITLE
Fix wls authentication provider

### DIFF
--- a/files/providers/wls_authentication_provider/create.py.erb
+++ b/files/providers/wls_authentication_provider/create.py.erb
@@ -109,10 +109,24 @@ try:
     #
     # Set resource specific values
     #
-    cd('AuthenticationProviders/'+name)
 <% provider_specific.each do | name, value | -%>
-    print 'Setting property <%= name -%> to <%= value -%>'
-    set('<%= name -%>','<%= value -%>')
+    current_value = get('<%= name -%>')
+    type_array = re.search("<type '(.*)'>", str(type(current_value)))
+    current_type = type_array.group(1)
+    if current_type == 'int':
+        print 'Setting integer property <%= name -%> to <%= value -%>'
+        set('<%= name -%>',int('<%= value -%>'))
+    elif current_type == 'float':
+        print 'Setting float property <%= name -%> to <%= value -%>'
+        set('<%= name -%>',float('<%= value -%>'))
+    elif current_type == 'array':
+        print 'Setting array property <%= name -%> to <%= value-%>'
+        set('<%= name -%>', jarray.array('<%= value -%>', String))
+    else:
+        print 'Setting property <%= name -%> to <%= value -%>'
+        #
+        # Type is a string or a NoneType
+        set('<%= name -%>','<%= value -%>')
 <% end -%>
 
     print "done"

--- a/files/providers/wls_authentication_provider/fetch.py.erb
+++ b/files/providers/wls_authentication_provider/fetch.py.erb
@@ -19,8 +19,12 @@ try:
   # Get all specified values
   #
 <% current_resource.provider_specific.keys.each do | key | -%>
-  <%= key -%> = str(get('<%= key -%>'))
-  print '<%= key -%> is ' + <%= key %>
+  try:
+    <%= key -%> = str(get('<%= key -%>'))
+    print '<%= key -%> is ' + <%= key %>
+  except:
+    print 'Troubles fetching <%= key -%>. Using empty value'
+    <%= key -%> = None
 <% end -%>
   #
   # All values fetched

--- a/files/providers/wls_authentication_provider/modify.py.erb
+++ b/files/providers/wls_authentication_provider/modify.py.erb
@@ -1,3 +1,4 @@
+import re
 # check the domain else we need to skip this (done in wls_access.rb)
 real_domain='<%= domain %>'
 
@@ -23,8 +24,23 @@ try:
     # Set resource specific values
     #
 <% provider_specific.each do | name, value | -%>
-    print 'Setting property <%= name -%> to <%= value -%>'
-    set('<%= name -%>','<%= value -%>')
+    current_value = get('<%= name -%>')
+    type_array = re.search("<type '(.*)'>", str(type(current_value)))
+    current_type = type_array.group(1)
+    if current_type == 'int':
+        print 'Setting integer property <%= name -%> to <%= value -%>'
+        set('<%= name -%>',int('<%= value -%>'))
+    elif current_type == 'float':
+        print 'Setting float property <%= name -%> to <%= value -%>'
+        set('<%= name -%>',float('<%= value -%>'))
+    elif current_type == 'array':
+        print 'Setting array property <%= name -%> to <%= value-%>'
+        set('<%= name -%>', jarray.array('<%= value -%>', String))
+    else:
+        print 'Setting property <%= name -%> to <%= value -%>'
+        #
+        # Type is a string or a NoneType
+        set('<%= name -%>','<%= value -%>')
 <% end -%>
 
     if control_flag:


### PR DESCRIPTION
Edwin,

Can you check this one out? What I've done is:

1. add an t`try` `except` block on fetching values. When a value cannot be fetched, it will continue with an empty value
2. I deduct the way to set the attribute, based on the type of the currrent value. This should allow setting all variables

If 2 works consistently, we could extract this into a method and use this everywhere. I think this would make a lot of settings much easier. 

Let me know what you think about it.