### PR TITLE
fmwcluster support without Hiera

### DIFF
--- a/manifests/utils/fmwcluster.pp
+++ b/manifests/utils/fmwcluster.pp
@@ -86,6 +86,7 @@ define orawls::utils::fmwcluster (
     if ( $version == 1213 or $version == 1221 ) {
       #shutdown adminserver for offline WLST scripts
       orawls::control{"ShutdownAdminServerForSoa${title}":
+        middleware_home_dir => $middleware_home_dir,
         weblogic_home_dir   => $weblogic_home_dir,
         jdk_home_dir        => $jdk_home_dir,
         wls_domains_dir     => $domains_dir,
@@ -196,6 +197,7 @@ define orawls::utils::fmwcluster (
 
       #shutdown adminserver for offline WLST scripts
       orawls::control{"ShutdownAdminServerForSoa${title}":
+        middleware_home_dir => $middleware_home_dir,
         weblogic_home_dir   => $weblogic_home_dir,
         jdk_home_dir        => $jdk_home_dir,
         wls_domains_dir     => $domains_dir,
@@ -360,6 +362,7 @@ define orawls::utils::fmwcluster (
 
       #startup adminserver for offline WLST scripts
       orawls::control{"StartupAdminServerForSoa${title}":
+        middleware_home_dir => $middleware_home_dir,
         weblogic_home_dir   => $weblogic_home_dir,
         jdk_home_dir        => $jdk_home_dir,
         wls_domains_dir     => $domains_dir,

--- a/manifests/utils/fmwcluster.pp
+++ b/manifests/utils/fmwcluster.pp
@@ -129,6 +129,7 @@ define orawls::utils::fmwcluster (
       }
       #startup adminserver for offline WLST scripts
       orawls::control{"StartupAdminServerForSoa${title}":
+        middleware_home_dir => $middleware_home_dir,
         weblogic_home_dir   => $weblogic_home_dir,
         jdk_home_dir        => $jdk_home_dir,
         wls_domains_dir     => $domains_dir,


### PR DESCRIPTION
Without Hiera, fmwcluster resource won't work since there is no way to pass in a middleware_home_dir to orawls::control