### PR TITLE
Added autorequire for wls_server_channel.

### DIFF
--- a/lib/puppet/type/wls_cluster.rb
+++ b/lib/puppet/type/wls_cluster.rb
@@ -196,5 +196,6 @@ module Puppet
        "#{domain}/#{datasourceforjobscheduler}"]
     }
 
+    autorequire(:wls_server_channel) { self[:servers].nil? ? '' : self[:servers].collect { |s| "#{domain}/#{s}:#{unicastbroadcastchannel}" } if unicastbroadcastchannel}
   end
 end


### PR DESCRIPTION
When creating a cluster the server channel must exists otherwise the creation of the cluster will fail.