### PR TITLE
Add new 'removeinfectedconnections' property to wls_datasource

### DIFF
--- a/files/providers/wls_datasource/create.py.erb
+++ b/files/providers/wls_datasource/create.py.erb
@@ -94,6 +94,10 @@ try:
     else:
       set('WrapTypes', 'false')
 
+<% unless removeinfectedconnections.nil? -%>
+    set('RemoveInfectedConnections', <% if removeinfectedconnections == :true -%>True<% else %>False<% end %>)
+<% end -%>
+
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
 

--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -2,7 +2,7 @@
 m = ls('/JDBCSystemResources',returnMap='true')
 
 f = open("/tmp/wlstScript.out", "w")
-print >>f, "name;target;targettype;drivername;jndinames;url;usexa;xaproperties;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist;mincapacity;statementcachesize;testconnectionsonreserve;secondstotrustidlepoolconnection;testfrequency;connectioncreationretryfrequency;rowprefetchenabled;rowprefetchsize;initsql;shrinkfrequencyseconds;wrapdatatypes"
+print >>f, "name;target;targettype;drivername;jndinames;url;usexa;xaproperties;user;testtablename;globaltransactionsprotocol;extraproperties;maxcapacity;initialcapacity;domain;fanenabled;onsnodelist;mincapacity;statementcachesize;testconnectionsonreserve;secondstotrustidlepoolconnection;testfrequency;connectioncreationretryfrequency;rowprefetchenabled;rowprefetchsize;initsql;shrinkfrequencyseconds;wrapdatatypes;removeinfectedconnections"
 for token in m:
     print '___'+token+'___'
     cd('/JDBCSystemResources/'+token + '/JDBCResource/' + token)
@@ -40,6 +40,11 @@ for token in m:
           wrapdatatypes = '1'
         else:
           wrapdatatypes = '0'
+
+        if get('RemoveInfectedConnections'):
+          removeinfectedconnections = '1'
+        else:
+          removeinfectedconnections = '0'
 
         cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCDataSourceParams/' + token )
         jndinames = get('JNDINames')
@@ -130,10 +135,10 @@ for token in m:
                 missing = 1
 
         if not tagged:
-            print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,','.join(target),','.join(targetType),driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes, removeinfectedconnections]))
         elif missing == 0:
-            print >>f, ";".join(map(quote, [domain+'/'+token,'inherited','inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,'inherited','inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes, removeinfectedconnections]))
         else:
-            print >>f, ";".join(map(quote, [domain+'/'+token,'not_inherited','not_inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes]))
+            print >>f, ";".join(map(quote, [domain+'/'+token,'not_inherited','not_inherited',driver,','.join(jndinames),url,usexa,xapropertiesCur,user,testTableName,globalTransactionsProtocol,','.join(properties),maxcapacity,initialcapacity,domain,fanenabled,onsnodelist,mincapacity,statementcachesize,testconnectionsonreserve,secondstotrustidlepoolconnection,testfrequency,connectioncreationretryfrequency,rowprefetchenabled,rowprefetchsize,initsql,shrinkfrequencyseconds, wrapdatatypes, removeinfectedconnections]))
 f.close()
 print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_datasource/modify.py.erb
+++ b/files/providers/wls_datasource/modify.py.erb
@@ -92,6 +92,10 @@ try:
     else:
       set('WrapTypes', 'false')
 
+<% unless removeinfectedconnections.nil? -%>
+    set('RemoveInfectedConnections', <% if removeinfectedconnections == :true -%>True<% else %>False<% end %>)
+<% end -%>
+
     cd('/JDBCSystemResources/' + name + '/JDBCResource/' + name + '/JDBCConnectionPoolParams/' + name )
     cmo.setTestTableName(testtablename)
 

--- a/lib/puppet/type/wls_datasource.rb
+++ b/lib/puppet/type/wls_datasource.rb
@@ -67,6 +67,7 @@ module Puppet
     property :initsql
     property :shrinkfrequencyseconds
     property :wrapdatatypes
+    property :removeinfectedconnections
 
     add_title_attributes(:datasource_name) do
       /^((.*\/)?(.*)?)$/

--- a/lib/puppet/type/wls_datasource/removeinfectedconnections.rb
+++ b/lib/puppet/type/wls_datasource/removeinfectedconnections.rb
@@ -1,0 +1,25 @@
+newproperty(:removeinfectedconnections, :boolean => true) do
+  include EasyType
+
+  desc 'Specifies whether a connection will be removed from the connection pool after the application uses the underlying vendor connection object.'
+
+  newvalues(:true, :false, '0', '1')
+
+  munge do |value|
+    case value
+    when true, "true", :true, '1'
+      :true
+    when false, "false", :false, '0'
+      :false
+    else
+      fail("#{value} must be a boolean")
+    end
+  end
+
+  to_translate_to_resource do |raw_resource|
+    return :true  if raw_resource['removeinfectedconnections'] == '1'
+    return :false if raw_resource['removeinfectedconnections'] == '0'
+    fail('BUG! removeinfectedconnections should have been \'0\' or \'1\'')
+  end
+
+end

--- a/spec/unit/puppet/type/wls_datasource_spec.rb
+++ b/spec/unit/puppet/type/wls_datasource_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:wls_datasource) do
+  describe 'when validating attributes' do
+    [ :domain, :name, :datasource_name, :provider ].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+    [ :ensure,
+      :connectioncreationretryfrequency,
+      :drivername,
+      :fanenabled,
+      :globaltransactionsprotocol,
+      :initialcapacity,
+      :initsql,
+      :jndinames,
+      :maxcapacity,
+      :mincapacity,
+      :password,
+      :removeinfectedconnections,
+      :rowprefetchenabled,
+      :rowprefetchsize,
+      :secondstotrustidlepoolconnection,
+      :shrinkfrequencyseconds,
+      :statementcachesize,
+      :target,
+      :targettype,
+      :testconnectionsonreserve,
+      :testfrequency,
+      :testtablename,
+      :url,
+      :user,
+      :usexa,
+      :wrapdatatypes,
+      :xaproperties].each do |prop|
+      it "should have a #{prop} property" do
+        expect(described_class.attrtype(prop)).to eq(:property)
+      end
+    end
+  end
+  describe 'when validating attribute values' do
+    describe 'removeinfectedconnections' do
+      it 'should accept booleans' do
+        expect { @ds = described_class.new( {:title => 'resourcetitle', :removeinfectedconnections => true})}.to_not raise_error
+        expect { @ds = described_class.new( {:title => 'resourcetitle', :removeinfectedconnections => false})}.to_not raise_error
+      end
+      it 'should munge \'0\' to :false' do
+        @ds = described_class.new( {:title => 'resourcetitle', :removeinfectedconnections => '0'})
+        expect(@ds[:removeinfectedconnections]).to eq(:false)
+      end
+      it 'should munge \'1\' to :true' do
+        @ds = described_class.new( {:title => 'resourcetitle', :removeinfectedconnections => '1'})
+        expect(@ds[:removeinfectedconnections]).to eq(:true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For consistency accepts '0', '1' as well as true/false.  Property is optional.  If not specified in a manifest, the existing state will not be altered.  See commits for more detailed comments.