### PR TITLE
Add type and provider for managing JMS resource security policies.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3748,6 +3748,28 @@ in hiera
          targettype:
            - 'Cluster'
 
+### wls_jms_security_policy
+
+it needs wls_setting and when identifier is not provided it will use the 'default'.
+
+or use puppet resource wls_jms_security_policy
+
+   # this will use default as wls_setting identifier
+   wls_jms_security_policy { 'jmsClusterModule:Topic1:receive':
+      ensure           => 'present',
+      destinationtype  => 'topic',
+      policyexpression => 'Usr(testuser1)',
+   }
+
+in hiera
+
+   # this will use default as wls_setting identifier
+   jms_security_policy_instances:
+      'jmsClusterModule:Topic1:receive':
+          ensure:           'present'
+          destinationtype:  'topic',
+          policyexpression: 'Usr(testuser1)',
+
 ### wls_jms_template
 
 it needs wls_setting and when identifier is not provided it will use the 'default'.

--- a/files/providers/wls_jms_security_policy/create.py.erb
+++ b/files/providers/wls_jms_security_policy/create.py.erb
@@ -1,0 +1,61 @@
+from weblogic.security.service import JMSResource
+
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+authorizationprovider = '<%= authorizationprovider %>'
+jmsmodule             = '<%= jmsmodule %>'
+destinationtype       = '<%= destinationtype %>'
+resourcename          = '<%= resourcename %>'
+action                = '<%= action %>'
+policyexpression      = '<%= policyexpression %>'
+
+# There may be other characters that need "encoding"...
+# It's very possible there's a better way to do this but I couldn't find anything obvious.
+<% encodedresourcename = resourcename.gsub(/\//, '@U') %>
+
+# Create an empty policy as a placeholder. We will set the policy rules with a call to setPolicyExpression().
+# This is much simpler than trying to translate a policy expression string into XML and including in this serialized policy definition.
+policy = """
+<Policy PolicyId="urn:bea:xacml:2.0:entitlement:resource:type@E@Fjms@G@M@Oapplication@E<%= jmsmodule %>@M@OdestinationType@E<%= destinationtype %>@M@Oresource@E<%= encodedresourcename %><% if action != :all %>@M@Oaction@E<%= action %><% end %>" RuleCombiningAlgId="urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:first-applicable">
+<Description><%= policyexpression %></Description>
+<Target>
+  <Resources>
+    <Resource>
+      <ResourceMatch MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+        <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">type=&lt;jms&gt;, application=<%= jmsmodule %>, destinationType=<%= destinationtype %>, resource=<%= resourcename %>, action=<%= action %></AttributeValue>
+        <ResourceAttributeDesignator AttributeId="urn:oasis:names:tc:xacml:2.0:resource:resource-ancestor-or-self" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
+      </ResourceMatch>
+    </Resource>
+  </Resources>
+</Target>
+<Rule RuleId="primary-rule" Effect="Permit">
+</Rule>
+<Rule RuleId="deny-rule" Effect="Deny">
+</Rule>
+</Policy>
+"""
+
+try:
+    cd('/')
+    securityrealm = cmo.getSecurityConfiguration().getDefaultRealm()
+    authorizer    = securityrealm.lookupAuthorizer(authorizationprovider)
+    print action
+    if action == 'all':
+        resource = weblogic.security.service.JMSResource(jmsmodule, destinationtype, resourcename, None)
+    else:
+        resource = weblogic.security.service.JMSResource(jmsmodule, destinationtype, resourcename, action)
+    resourceid = resource.toString()
+    print resourceid
+
+    # Add our "empty" policy before we set the policy expression.
+    authorizer.addPolicy(policy)
+    authorizer.setPolicyExpression(resourceid, policyexpression)
+
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/files/providers/wls_jms_security_policy/destroy.py.erb
+++ b/files/providers/wls_jms_security_policy/destroy.py.erb
@@ -1,0 +1,31 @@
+from weblogic.security.service import JMSResource
+
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+authorizationprovider = '<%= authorizationprovider %>'
+jmsmodule             = '<%= jmsmodule %>'
+destinationtype       = '<%= destinationtype %>'
+resourcename          = '<%= resourcename %>'
+action                = '<%= action %>'
+
+if action == 'all':
+  actionname = None
+else:
+  actionname = action
+
+try:
+    cd('/')
+    securityRealm = cmo.getSecurityConfiguration().getDefaultRealm()
+    authorizer = securityRealm.lookupAuthorizer(authorizationprovider)
+    resource = weblogic.security.service.JMSResource(jmsmodule, destinationtype, resourcename, actionname)
+    resourceId = resource.toString()
+    authorizer.removePolicy(resourceId)
+
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/files/providers/wls_jms_security_policy/index.py.erb
+++ b/files/providers/wls_jms_security_policy/index.py.erb
@@ -1,0 +1,53 @@
+from weblogic.security.service import JMSResource
+
+f = open("/tmp/wlstScript.out", "w")
+print >>f, "name;domain;authorizationprovider;jmsmodule;destinationtype;resourcename;action;policyexpression"
+
+securityRealm = cmo.getSecurityConfiguration().getDefaultRealm()
+authorizer = securityRealm.lookupAuthorizer('XACMLAuthorizer')
+
+# get all jms resources
+jmsModules = ls('/JMSSystemResources',returnMap='true')
+resourceTypes = [
+    ('Topics','topic'),
+    ('Queues','queue'),
+    ('DistributedTopics','topic'),
+    ('DistributedQueues','queue'),
+    ('UniformDistributedTopics','topic'),
+    ('UniformDistributedQueues','queue')
+]
+jmsResources = []
+
+# First, collect all JMS resources (queues/topics) in the domain
+for jmsModule in jmsModules:
+  cd('/JMSSystemResources/'+jmsModule+'/JMSResource/'+jmsModule)
+  for resourceType in resourceTypes:
+      resources = ls(resourceType[0],returnMap='true')
+      for resource in resources:
+          for action in [None, 'send', 'receive', 'browse']:
+              jmsResources.append(JMSResource(jmsModule, resourceType[1], resource, action))
+
+# Now find all JMS resources that have security policies defined
+for jmsResource in jmsResources:
+    resourceId = jmsResource.toString()
+    print resourceId
+    if authorizer.policyExists(resourceId):
+        if authorizer.getPolicyExpression(resourceId) == None:
+            policyExpression = ""
+        else:
+            policyExpression = authorizer.getPolicyExpression(resourceId)
+
+        authorizerName  = authorizer.getName()
+        jmsModuleName   = jmsResource.getApplicationName()
+        resourceName    = jmsResource.getResourceName()
+        destinationType = jmsResource.getDestinationType()
+        if jmsResource.getActionName() == None:
+            actionName = 'all'
+        else:
+            actionName = jmsResource.getActionName()
+
+        print resourceId + ', policyexpression=' + policyExpression
+        print >>f, ";".join(map(quote, [domain+'/'+jmsModuleName+":"+resourceName+":"+actionName,domain,authorizerName,jmsModuleName,destinationType,resourceName,actionName,policyExpression]))
+
+f.close()
+print "~~~~COMMAND SUCCESFULL~~~~"

--- a/files/providers/wls_jms_security_policy/modify.py.erb
+++ b/files/providers/wls_jms_security_policy/modify.py.erb
@@ -1,0 +1,32 @@
+from weblogic.security.service import JMSResource
+
+# check the domain else we need to skip this (done in wls_access.rb)
+real_domain='<%= domain %>'
+
+
+authorizationprovider = '<%= authorizationprovider %>'
+jmsmodule             = '<%= jmsmodule %>'
+destinationtype       = '<%= destinationtype %>'
+resourcename          = '<%= resourcename %>'
+action                = '<%= action %>'
+policyexpression      = '<%= policyexpression %>'
+
+if action == 'all':
+  actionname = None
+else:
+  actionname = action
+
+try:
+    cd('/')
+    securityRealm = cmo.getSecurityConfiguration().getDefaultRealm()
+    authorizer = securityRealm.lookupAuthorizer(authorizationprovider)
+    resource = weblogic.security.service.JMSResource(jmsmodule, destinationtype, resourcename, actionname)
+    resourceId = resource.toString()
+    authorizer.setPolicyExpression(resourceId, policyexpression)
+
+    print "~~~~COMMAND SUCCESFULL~~~~"
+
+except:
+    print "Unexpected error:", sys.exc_info()[0]
+    print "~~~~COMMAND FAILED~~~~"
+    raise

--- a/lib/puppet/provider/wls_jms_security_policy/simple.rb
+++ b/lib/puppet/provider/wls_jms_security_policy/simple.rb
@@ -1,0 +1,9 @@
+require 'easy_type'
+require 'utils/wls_access'
+
+Puppet::Type.type(:wls_jms_security_policy).provide(:simple) do
+  include EasyType::Provider
+
+  desc 'Manage security policies of a JMS resource (queue or topic) via regular WLST'
+  mk_resource_methods
+end

--- a/lib/puppet/type/wls_jms_security_policy.rb
+++ b/lib/puppet/type/wls_jms_security_policy.rb
@@ -1,0 +1,55 @@
+require File.dirname(__FILE__) + '/../../orawls_core'
+
+
+module Puppet
+  Type.newtype(:wls_jms_security_policy) do
+    include EasyType
+    include Utils::WlsAccess
+    extend Utils::TitleParser
+
+    desc 'This resource allows you to manage security authorization policies in an WebLogic Security Realm.'
+
+    ensurable
+
+    set_command(:wlst)
+
+    to_get_raw_resources do
+      Puppet.info "index #{name}"
+      environment = { 'action' => 'index', 'type' => 'wls_jms_security_policy' }
+      wlst template('puppet:///modules/orawls/providers/wls_jms_security_policy/index.py.erb', binding), environment
+    end
+
+    on_create do | command_builder |
+      Puppet.info "create #{name}"
+      template('puppet:///modules/orawls/providers/wls_jms_security_policy/create.py.erb', binding)
+    end
+
+    on_modify do | command_builder |
+      Puppet.info "modify #{name}"
+      template('puppet:///modules/orawls/providers/wls_jms_security_policy/modify.py.erb', binding)
+    end
+
+    on_destroy do | command_builder |
+      Puppet.info "destroy #{name}"
+      template('puppet:///modules/orawls/providers/wls_jms_security_policy/destroy.py.erb', binding)
+    end
+
+    property  :policyexpression
+    parameter :domain
+    parameter :name
+    parameter :jmsmodule
+    parameter :destinationtype
+    parameter :resourcename
+    parameter :action
+    parameter :authorizationprovider
+    parameter :timeout
+
+    add_title_attributes(:jmsmodule, :resourcename, :action) do
+      /^((.*\/)?(.*):(.*):(.*))$/
+    end
+
+    autorequire(:wls_jms_queue) { "#{domain}/#{jmsmodule}:#{resourcename}" if destinationtype == :queue }
+    autorequire(:wls_jms_topic) { "#{domain}/#{jmsmodule}:#{resourcename}" if destinationtype == :topic }
+
+  end
+end

--- a/lib/puppet/type/wls_jms_security_policy/action.rb
+++ b/lib/puppet/type/wls_jms_security_policy/action.rb
@@ -1,0 +1,12 @@
+newparam(:action) do
+  include EasyType
+
+  desc 'action to apply authorization policy on for a queue or topic'
+
+  newvalues(:send, :receive, :browse, :all)
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['action']
+  end
+
+end

--- a/lib/puppet/type/wls_jms_security_policy/authorizationprovider.rb
+++ b/lib/puppet/type/wls_jms_security_policy/authorizationprovider.rb
@@ -1,0 +1,12 @@
+newparam(:authorizationprovider) do
+  include EasyType
+
+  desc 'The security authorization providers of the domain'
+
+  defaultto 'XACMLAuthorizer'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['authorizationprovider']
+  end
+
+end

--- a/lib/puppet/type/wls_jms_security_policy/destinationtype.rb
+++ b/lib/puppet/type/wls_jms_security_policy/destinationtype.rb
@@ -1,0 +1,12 @@
+newparam(:destinationtype) do
+  include EasyType
+
+  desc 'The destination type of a jms resource (queue or topic)'
+
+  newvalues(:queue, :topic)
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['destinationtype']
+  end
+
+end

--- a/lib/puppet/type/wls_jms_security_policy/policyexpression.rb
+++ b/lib/puppet/type/wls_jms_security_policy/policyexpression.rb
@@ -1,0 +1,10 @@
+newproperty(:policyexpression) do
+  include EasyType
+
+  desc 'A string representation of an security authorization policy'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['policyexpression']
+  end
+
+end

--- a/lib/puppet/type/wls_jms_security_policy/resourcename.rb
+++ b/lib/puppet/type/wls_jms_security_policy/resourcename.rb
@@ -1,0 +1,10 @@
+newparam(:resourcename) do
+  include EasyType
+
+  desc 'The name of the jms resource'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['resourcename']
+  end
+
+end


### PR DESCRIPTION
Hey Edwin,

This is a new custom type/provider for managing the security policies on JMS queues and topics. It handles adding a policy, removing a policy and updating a policy. It uses the policy expression syntax. The easiest way to figure out the right string for a policy expression is to create it manually in admin console then use WLST to call `getPolicyExpression()`.

It has been tested on CentOS 6.6 and Weblogic 10.3.6.

Let me know if there's anything you'd like me to change.

Bryan