### PR TITLE
Adding 'cluster' property to resource 'wls_server'.

### DIFF
--- a/files/providers/wls_server/create.py.erb
+++ b/files/providers/wls_server/create.py.erb
@@ -11,6 +11,8 @@ arguments     = '<%= arguments.join(' ') %>'
 machineName   = '<%= machine %>'
 bea_home      = '<%= bea_home %>'
 
+cluster_name = '<%= cluster %>'.strip()
+
 logFilename                 = '<%= logfilename %>'
 log_http_Filename           = '<%= log_http_filename %>'
 log_http_format             = '<%= log_http_format %>'
@@ -78,6 +80,9 @@ try:
 
     cd('/Servers/'+name)
     set('Machine',getMBean('/Machines/'+machineName))
+
+    if cluster_name :
+      cmo.setCluster(getMBean('/Clusters/'+cluster_name))
 
     print "Change Notes"
     if server_parameters and server_parameters != 'None':
@@ -194,3 +199,4 @@ try:
 
 except:
     report_back_error()
+

--- a/files/providers/wls_server/index.py.erb
+++ b/files/providers/wls_server/index.py.erb
@@ -2,7 +2,7 @@
 cd("/")
 m = ls('/Servers',returnMap='true')
 
-f = open_file("name;listenaddress;listenport;logintimeout;ssllistenport;sslenabled;sslhostnameverificationignored;sslhostnameverifier;two_way_ssl;client_certificate_enforced;useservercerts;machine;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_number_of_files_limited;tunnelingenabled;log_http_filename;log_http_format;log_http_format_type;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size;log_redirect_stderr_to_server;log_redirect_stdout_to_server;restart_max;log_http_file_count;log_http_number_of_files_limited;bea_home;weblogic_plugin_enabled;listenportenabled;auto_restart;autokillwfail;server_parameters;frontendhost;frontendhttpport;frontendhttpsport;log_date_pattern")
+f = open_file("name;listenaddress;listenport;logintimeout;ssllistenport;sslenabled;sslhostnameverificationignored;sslhostnameverifier;two_way_ssl;client_certificate_enforced;useservercerts;machine;cluster;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_number_of_files_limited;tunnelingenabled;log_http_filename;log_http_format;log_http_format_type;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size;log_redirect_stderr_to_server;log_redirect_stdout_to_server;restart_max;log_http_file_count;log_http_number_of_files_limited;bea_home;weblogic_plugin_enabled;listenportenabled;auto_restart;autokillwfail;server_parameters;frontendhost;frontendhttpport;frontendhttpsport;log_date_pattern")
 for token in m:
   print '___'+token+'___'
   cd('/Servers/'+token)
@@ -96,7 +96,13 @@ for token in m:
       if token2:
          machine = token2
 
-  add_index_entry(f, [domain+'/'+token, listenAddress, listenPort, logintimeout, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, sslhostnameverifier, two_way_ssl, client_certificate_enforced, useservercerts, machine, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_number_of_files_limited, tunnelingenabled,log_http_filename,log_http_format,log_http_format_type,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size, log_redirect_stderr_to_server, log_redirect_stdout_to_server, restart_max, log_http_file_count,log_http_number_of_files_limited, bea_home, weblogic_plugin_enabled, listenPortEnabled,auto_restart,autokillwfail,server_parameters,frontendhost,frontendhttpport,frontendhttpsport,log_date_pattern])
+  cluster = ''
+  cluster_query = ls('/Servers/'+token+'/Cluster', returnMap = 'true')
+  if cluster_query :
+    for c in cluster_query :
+      cluster = c[0]
+
+  add_index_entry(f, [domain+'/'+token, listenAddress, listenPort, logintimeout, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, sslhostnameverifier, two_way_ssl, client_certificate_enforced, useservercerts, machine, cluster, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_number_of_files_limited, tunnelingenabled,log_http_filename,log_http_format,log_http_format_type,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size, log_redirect_stderr_to_server, log_redirect_stdout_to_server, restart_max, log_http_file_count,log_http_number_of_files_limited, bea_home, weblogic_plugin_enabled, listenPortEnabled,auto_restart,autokillwfail,server_parameters,frontendhost,frontendhttpport,frontendhttpsport,log_date_pattern])
 
 f.close()
 report_back_success()

--- a/files/providers/wls_server/modify.py.erb
+++ b/files/providers/wls_server/modify.py.erb
@@ -6,6 +6,7 @@ manage_classpath      = False
 manage_bea_home       = False
 manage_listenaddress  = False
 manage_machine        = False
+manage_cluster        = False
 
 name          = '<%= server_name %>'
 
@@ -32,6 +33,11 @@ manage_listenaddress = True
 <% unless machine.nil? %>
 machineName    = '<%= machine %>'
 manage_machine = True
+<% end %>
+
+<% unless cluster.nil? %>
+cluster_name = '<%= cluster %>'.strip()
+manage_cluster = True
 <% end %>
 
 logFilename                      = '<%= logfilename %>'
@@ -98,6 +104,12 @@ try:
           cmo.setMachine(None)
       else:
           set('Machine', getMBean('/Machines/'+machineName))
+
+    if manage_cluster :
+      if cluster_name :
+        cmo.setCluster(getMBean('/Clusters/'+cluster_name))
+      else:
+        cmo.setCluster(None)
 
     print "Change Notes"
     set_attribute_value('Notes', server_parameters, use_default_value_when_empty)

--- a/lib/puppet/type/wls_server.rb
+++ b/lib/puppet/type/wls_server.rb
@@ -57,6 +57,7 @@ module Puppet
     property :listenport
     property :listenportenabled
     property :machine
+    property :cluster
     property :classpath
     property :arguments
     property :bea_home

--- a/lib/puppet/type/wls_server/cluster.rb
+++ b/lib/puppet/type/wls_server/cluster.rb
@@ -1,0 +1,11 @@
+newproperty(:cluster) do
+  include EasyType
+
+  desc 'The cluster which contains a given server'
+
+  to_translate_to_resource do | raw_resource|
+    return '' if raw_resource['cluster'].nil?
+    raw_resource['cluster']
+  end
+
+end


### PR DESCRIPTION
On issue #317 , I mentioned an inability on configuring a Weblogic Cluster without knowing a priori all servers and machines on the infrastructure.

With this update, "cluster" property to the "wls_server" resource that allows the server to provide which cluster it will belong to. This partially solves the problem, since a puppet script can declare which clusters are available in the admin server and its main properties, and on each managed server, which cluster it will belong.

There's a remaining issue on updating the wls_server cluster and machine information, since it requires a managed server restart, before activation. This resource still don't solve these edge cases.