### PR TITLE
OHS Standalone installation

### DIFF
--- a/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
+++ b/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:wls_adminserver).provide(:wls_adminserver) do
     custom_trust                = resource[:custom_trust]
     trust_keystore_file         = resource[:trust_keystore_file]
     trust_keystore_passphrase   = resource[:trust_keystore_passphrase]
+    ohs_standalone_server       = resource[:ohs_standalone_server]
 
     Puppet.debug "adminserver custom trust: #{custom_trust}"
 
@@ -31,9 +32,17 @@ Puppet::Type.type(:wls_adminserver).provide(:wls_adminserver) do
     end
 
     if action == :start
-      wls_action = "nmStart(\"#{name}\")"
+      if "#{ohs_standalone_server}" == 'true'
+        wls_action = "nmStart(serverName=\"#{name}\", serverType=\"OHS\")"
+      else
+        wls_action = "nmStart(\"#{name}\")"
+      end
     else
-      wls_action = "nmKill(\"#{name}\")"
+      if "#{ohs_standalone_server}" == 'true'
+        wls_action = "nmKill(serverName=\"#{name}\", serverType=\"OHS\")"
+      else
+        wls_action = "nmKill(\"#{name}\")"
+      end
     end
 
     if "#{nodemanager_secure_listener}" == 'true'

--- a/lib/puppet/type/wls_adminserver.rb
+++ b/lib/puppet/type/wls_adminserver.rb
@@ -49,6 +49,16 @@ module Puppet
       EOT
     end
 
+    newparam(:ohs_standalone_server) do
+      desc <<-EOT
+        Flag to determinate if the server is a OHS standalone server.
+      EOT
+
+      newvalues(:true, :false)
+
+      defaultto :false
+    end
+
     newparam(:domain_name) do
       desc <<-EOT
         The weblogic domain name.

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -40,7 +40,9 @@ define orawls::control (
 
   $domain_dir = "${domains_dir}/${domain_name}"
 
-  if $server_type == 'admin' {
+  if $server_type == 'admin' or $server_type == 'ohs_standalone' {
+    $ohs_standalone_server = ($server_type == 'ohs_standalone')
+
     wls_adminserver{"${title}:AdminServer":
       ensure                      => $action,   #running|start|abort|stop
       server_name                 => $server,
@@ -58,6 +60,7 @@ define orawls::control (
       custom_trust                => $custom_trust,
       trust_keystore_file         => $trust_keystore_file,
       trust_keystore_passphrase   => $trust_keystore_passphrase,
+      ohs_standalone_server       => $ohs_standalone_server,
     }
   }
   else {

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -9,7 +9,7 @@ define orawls::domain (
   $jdk_home_dir                          = hiera('wls_jdk_home_dir'), # /usr/java/jdk1.7.0_45
   $wls_domains_dir                       = hiera('wls_domains_dir'               , undef),
   $wls_apps_dir                          = hiera('wls_apps_dir'                  , undef),
-  $domain_template                       = hiera('domain_template'               , 'standard'), # adf|adf_restricted|osb|osb_soa_bpm|osb_soa|soa|soa_bpm|bam|wc|wc_wcc_bpm|oud
+  $domain_template                       = hiera('domain_template'               , 'standard'), # adf|adf_restricted|osb|osb_soa_bpm|osb_soa|soa|soa_bpm|bam|wc|wc_wcc_bpm|oud|ohs_standalone
   $bam_enabled                           = true,  #only for SOA Suite
   $b2b_enabled                           = false, #only for SOA Suite 12.1.3 with b2b
   $ess_enabled                           = false, #only for SOA Suite 12.1.3
@@ -53,6 +53,10 @@ define orawls::domain (
   $custom_identity_alias                 = undef,
   $custom_identity_privatekey_passphrase = undef,
   $create_rcu                            = hiera('create_rcu', true),
+
+  $ohs_standalone_listen_address         = undef,
+  $ohs_standalone_listen_port            = undef,
+  $ohs_standalone_ssl_listen_port        = undef,
 )
 {
   if ( $wls_domains_dir == undef or $wls_domains_dir == '' ) {
@@ -133,7 +137,12 @@ define orawls::domain (
       $templateApplCore  = "${middleware_home_dir}/oracle_common/common/templates/applications/oracle.applcore.model.stub.12.1.3_template.jar"
       $templateWSMPM     = "${middleware_home_dir}/oracle_common/common/templates/wls/oracle.wsmpm_template_12.1.2.jar"
 
-      $templateOHS       = "${middleware_home_dir}/ohs/common/templates/wls/ohs_managed_template_12.1.2.jar"
+      if $domain_template == 'ohs_standalone' {
+        $templateOHS   = "${middleware_home_dir}/ohs/common/templates/wls/ohs_standalone_template_12.1.2.jar"
+      }
+      else {
+        $templateOHS       = "${middleware_home_dir}/ohs/common/templates/wls/ohs_managed_template_12.1.2.jar"
+      }
       $templateEMWebTier = "${middleware_home_dir}/em/common/templates/wls/oracle.em_webtier_template_12.1.2.jar"
 
     } elsif $version == 1213 {
@@ -218,9 +227,21 @@ define orawls::domain (
 
     $templateUCM          = "${middleware_home_dir}/Oracle_WCC1/common/templates/applications/oracle.ucm.cs_template_11.1.1.jar"
 
-    $templateFile   = 'orawls/domains/domain.py.erb'
+    if $domain_template != 'ohs_standalone' {
+      $templateFile = 'orawls/domains/domain.py.erb'
+    }
 
-    if $domain_template == 'standard' {
+    if $domain_template == 'ohs_standalone' {
+      if ( $version == 1212 ) {
+        $extensionsTemplateFile = undef
+        $wlstPath       = "${middleware_home_dir}/ohs/common/bin"
+        $templateFile = 'orawls/ohs/domain.py.erb'
+      }
+      else {
+        fail("OHS Standalone domain configuration currently works only with version 12.1.2. Version ${version} not supported.")
+      }
+    }
+    elsif $domain_template == 'standard' {
       $extensionsTemplateFile = undef
       $wlstPath       = "${weblogic_home_dir}/common/bin"
 

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -494,7 +494,7 @@ define orawls::domain (
       } elsif ( $domain_template in ['soa', 'osb', 'osb_soa_bpm', 'osb_soa', 'soa_bpm', 'bam'] ){
         $rcu_domain_template = 'soa'
 
-      } else {
+      } elsif ($create_rcu == undef or $create_rcu == true) {
         fail('unkown domain_template for rcu with version 1212 or 1213')
       }
 

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -24,6 +24,7 @@ define orawls::fmw(
   $remote_file          = true,                              # true|false
   $log_output           = false,                             # true|false
   $temp_directory       = hiera('wls_temp_dir','/tmp'),      # /tmp directory
+  $ohs_mode             = hiera('ohs_mode', 'colocated'),
   $oracle_inventory_dir = undef,
 )
 {
@@ -67,6 +68,14 @@ define orawls::fmw(
   #After converting all spaces to underscores, remove all non alphanumeric characters (allow hypens and underscores too)
   $convert_spaces_to_underscores = regsubst($title,'\s','_','G')
   $sanitised_title = regsubst ($convert_spaces_to_underscores,'[^a-zA-Z0-9_-]','','G')
+
+  if ($ohs_mode == 'standalone') {
+    $install_type = 'Standalone HTTP Server (Managed independently of WebLogic server)'
+  } elsif ($ohs_mode == 'colocated') {
+    $install_type = 'Colocated HTTP Server (Managed through WebLogic server)'
+  } else {
+    fail("Unrecognized parameter ohs_mode: ${ohs_mode}, please use colocated|standalone")
+  }
 
   if ( $fmw_product == 'adf' ) {
     $fmw_silent_response_file = 'orawls/fmw_silent_adf.rsp.erb'

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -24,10 +24,16 @@ define orawls::fmw(
   $remote_file          = true,                              # true|false
   $log_output           = false,                             # true|false
   $temp_directory       = hiera('wls_temp_dir','/tmp'),      # /tmp directory
+  $oracle_inventory_dir = undef,
 )
 {
   $exec_path    = "${jdk_home_dir}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:"
-  $oraInventory = "${oracle_base_home_dir}/oraInventory"
+
+  if $oracle_inventory_dir == undef {
+    $oraInventory = "${oracle_base_home_dir}/oraInventory"
+  } else {
+    $oraInventory = $oracle_inventory_dir
+  }
 
   case $::kernel {
     'Linux': {

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -29,6 +29,7 @@ define orawls::nodemanager (
   $log_output                            = false, # true|false
   $sleep                                 = hiera('wls_nodemanager_sleep'         , 20), # default sleep time
   $properties                            = {},
+  $ohs_standalone                        = false,
 )
 {
 
@@ -38,12 +39,16 @@ define orawls::nodemanager (
     $domains_dir =  $wls_domains_dir
   }
 
-
   if ( $version == 1111 or $version == 1036 or $version == 1211 ) {
     $nodeMgrHome = "${weblogic_home_dir}/common/nodemanager"
     $startHome   = "${weblogic_home_dir}/server/bin"
   } elsif $version == 1212 or $version == 1213 or $version == 1221 {
-    $nodeMgrHome = "${domains_dir}/${domain_name}/nodemanager"
+    if $ohs_standalone == true and $version == 1212 {
+      $nodeMgrHome = "${domains_dir}/${domain_name}/bin"
+    } else {
+      $nodeMgrHome = "${domains_dir}/${domain_name}/nodemanager"
+    }
+
     $startHome   = "${domains_dir}/${domain_name}/bin"
   } else {
     $nodeMgrHome = "${weblogic_home_dir}/common/nodemanager"

--- a/templates/ohs/domain.py.erb
+++ b/templates/ohs/domain.py.erb
@@ -1,0 +1,32 @@
+# Directories
+domainName = '<%= @domain_name %>'
+domainDir = '<%= @domain_dir %>'
+
+# Read OHS Standalone template
+readTemplate('<%= @templateOHS %>')
+
+# Configure Nodemanager
+
+cd('/')
+create(domainName, 'SecurityConfiguration')
+cd('SecurityConfiguration/' + domainName)
+set('NodeManagerUsername', '<%= @nodemanager_username %>')
+set('NodeManagerPasswordEncrypted', '<%= @nodemanager_password %>')
+setOption('NodeManagerType', 'PerDomainNodeManager')
+
+# Optional Steps:
+# The standalone OHS template already comes with an
+# out-of-the-box machine ('localmachine') and a single
+# instance of OHS ('ohs1') with default configuration
+# values. The remaining steps are needed only if the
+# out-of-the-box defaults need to be changed
+
+cd('/OHS/ohs1')
+cmo.setAdminHost('<%= @adminserver_address %>')
+cmo.setAdminPort('<%= @adminserver_port %>')
+cmo.setListenAddress('<%= @ohs_standalone_listen_address %>')
+cmo.setListenPort('<%= @ohs_standalone_listen_port %>')
+cmo.setSSLListenPort('<%= @ohs_standalone_ssl_listen_port %>')
+
+writeDomain(domainDir)
+closeTemplate()

--- a/templates/web_http_server_1212.rsp.erb
+++ b/templates/web_http_server_1212.rsp.erb
@@ -9,7 +9,7 @@ Response File Version=1.0.0.0.0
 ORACLE_HOME=<%= @middleware_home_dir %>
 
 #Set this variable value to the Installation Type selected as either Standalone HTTP Server (Managed independently of WebLogic server) OR Colocated HTTP Server (Managed through WebLogic server)
-INSTALL_TYPE=Colocated HTTP Server (Managed through WebLogic server)
+INSTALL_TYPE=<%= @install_type %>
 
 #Provide the My Oracle Support Username. If you wish to ignore Oracle Configuration Manager configuration provide empty string for user name.
 MYORACLESUPPORT_USERNAME=


### PR DESCRIPTION
The changes made in this PR allows the module to install and configure OHS server in standalone mode. Also made a workaround to avoid dependency problems with defined "File" resources which are responsible to create some directories needed for Weblogic and/or OHS installation. Fix #319 