### PR TITLE
Bugfix for cases when setting an attribute's value to 0

### DIFF
--- a/files/wlst/common.py.erb
+++ b/files/wlst/common.py.erb
@@ -211,7 +211,7 @@ def set_attribute_value(mbean_attribute, value=None, set_default=True):
     null_value = fields[2]
     #
     # if the value is not specified set the default value if it defined
-    if value:
+    if value is not None and value != "":
         attribute_value = str(value)
     else:
         if not set_default:


### PR DESCRIPTION
Bugfix for cases when setting an attribute's value to 0 would cause the attribute to not be set at all (even though Puppet would report it as being changed).