### PR TITLE
Allow Groups to be managed or not

### DIFF
--- a/files/providers/wls_group/modify.py.erb
+++ b/files/providers/wls_group/modify.py.erb
@@ -8,6 +8,7 @@ realm                  = '<%= realm %>'
 authenticationprovider = '<%= authenticationprovider %>'
 description            = '<%= description %>'
 users                  = '<%= users %>'.split(",")
+manage_group           = '<%= manage_group %>'
 
 try:
     cd('/')
@@ -28,9 +29,14 @@ try:
     for user in users_to_add:
       print 'Adding user: ' + user
       atnr.addMemberToGroup(name,user)
-    for user in users_to_remove:
-      print 'Removing user: ' + user
-      atnr.removeMemberFromGroup(name,user)
+
+    if manage_group == 'true':
+      for user in users_to_remove:
+        print 'Removing user: ' + user
+        atnr.removeMemberFromGroup(name,user)
+    else:
+      print 'Skipping Removing Users'
+	
     report_back_success()
 
 except:

--- a/lib/puppet/type/wls_group.rb
+++ b/lib/puppet/type/wls_group.rb
@@ -41,6 +41,7 @@ module Puppet
     parameter :name
     parameter :group_name
     parameter :timeout
+    parameter :manage_group
     property :realm
     property :authenticationprovider
     property :users

--- a/lib/puppet/type/wls_group/manage_group.rb
+++ b/lib/puppet/type/wls_group/manage_group.rb
@@ -1,0 +1,14 @@
+newparam(:manage_group) do
+  include EasyType
+  include EasyType::Validators::Name
+
+  desc 'Modify Current Group Members'
+  defaultto 'true'
+
+  newvalues('true', 'false')
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['manage_group']
+  end
+
+end


### PR DESCRIPTION
In relation to issue #329 I've added a manage_group parameter. We ran into an issue were we couldn't upgrade to the later version of the module due to the refactor as mentioned in the issue. The reason for this was we added an additional user to the Administrators group during the puppet run. The WLS user configured to run WLST then didn't have an privilege to create any further WLS resources. So the puppet run just hangs. I've left the default to be true, Its probably an edge case that this scenario happens.

Hope this is ok, I had a slight issue with the commit so it maybe not to you're liking.
