### PR TITLE
Support for JRockit

### DIFF
--- a/files/wlst/common.py.erb
+++ b/files/wlst/common.py.erb
@@ -4,6 +4,7 @@
 #
 import re
 import jarray
+import traceback
 
 
 def report_back_success():


### PR DESCRIPTION
Previously, while using this module, I wasn't able to use some of the module's defined types (particularly wls_server) due to no support for JRockit. After much effort, I've discovered that in order to use JRockit and this module, a python library must be imported in order for it to work. Thus, inclusion of this code (one line) will result in everyone else being able to use this module along with JRockit if they so desire to.