### PR TITLE
Puppet.info -> Puppet.debug for Index Resource functions

### DIFF
--- a/lib/puppet/provider/opatch/opatch.rb
+++ b/lib/puppet/provider/opatch/opatch.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:opatch).provide(:opatch) do
     orainst_dir             = resource[:orainst_dir]
 
     command  = oracle_product_home_dir + '/OPatch/opatch lsinventory -patch_id -oh ' + oracle_product_home_dir + ' -invPtrLoc ' + orainst_dir + '/oraInst.loc'
-    Puppet.info "opatch_status for patch #{patchName} command: #{command}"
+    Puppet.debug "opatch_status for patch #{patchName} command: #{command}"
 
     kernel = Facter.value(:kernel)
     su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''

--- a/lib/puppet/type/wls_authentication_provider.rb
+++ b/lib/puppet/type/wls_authentication_provider.rb
@@ -24,7 +24,7 @@ module Puppet
 
       **ATTENTION:**
 
-      After the creation or modification of a wls_authentication_provider you'll need a restart from the 
+      After the creation or modification of a wls_authentication_provider you'll need a restart from the
       Admin server. If you don't restart the server, the changes will not be applied. In some cases this means
       that Puppet will try to re-create the wls_authentication_provider and will produce an WLST error.
 
@@ -35,7 +35,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_authentication_provider' }
       wlst template('puppet:///modules/orawls/providers/wls_authentication_provider/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_cluster.rb
+++ b/lib/puppet/type/wls_cluster.rb
@@ -15,7 +15,7 @@ module Puppet
     # set_command(:controller)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_cluster', 'rest_url' => '/management/weblogic/latest/domainConfig/clusters?links=none' }
 
       wlst template('puppet:///modules/orawls/providers/wls_cluster/index.py.erb', binding), environment

--- a/lib/puppet/type/wls_coherence_cluster.rb
+++ b/lib/puppet/type/wls_coherence_cluster.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_coherence_cluster' }
       wlst template('puppet:///modules/orawls/providers/wls_coherence_cluster/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_coherence_server.rb
+++ b/lib/puppet/type/wls_coherence_server.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_coherence_server' }
       wlst template('puppet:///modules/orawls/providers/wls_coherence_server/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_datasource.rb
+++ b/lib/puppet/type/wls_datasource.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_datasource' }
       wlst template('puppet:///modules/orawls/providers/wls_datasource/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_deployment.rb
+++ b/lib/puppet/type/wls_deployment.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_deployment' }
       wlst template('puppet:///modules/orawls/providers/wls_deployment/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_domain.rb
+++ b/lib/puppet/type/wls_domain.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_domain' }
       wlst template('puppet:///modules/orawls/providers/wls_domain/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_domain_partition.rb
+++ b/lib/puppet/type/wls_domain_partition.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_domain_partition' }
       wlst template('puppet:///modules/orawls/providers/wls_domain_partition/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_domain_partition_resource_group.rb
+++ b/lib/puppet/type/wls_domain_partition_resource_group.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_domain_partition_resource_group' }
       wlst template('puppet:///modules/orawls/providers/wls_domain_partition_resource_group/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_domain_partition_resource_group_deployment.rb
+++ b/lib/puppet/type/wls_domain_partition_resource_group_deployment.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_domain_partition_resource_group_deployment' }
       wlst template('puppet:///modules/orawls/providers/wls_domain_partition_resource_group_deployment/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_dynamic_cluster.rb
+++ b/lib/puppet/type/wls_dynamic_cluster.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_dynamic_cluster' }
       wlst template('puppet:///modules/orawls/providers/wls_dynamic_cluster/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_file_persistence_store.rb
+++ b/lib/puppet/type/wls_file_persistence_store.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_file_persistence_store' }
       wlst template('puppet:///modules/orawls/providers/wls_file_persistence_store/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_foreign_jndi_provider.rb
+++ b/lib/puppet/type/wls_foreign_jndi_provider.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_foreign_jndi_provider' }
       wlst template('puppet:///modules/orawls/providers/wls_foreign_jndi_provider/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_foreign_jndi_provider_link.rb
+++ b/lib/puppet/type/wls_foreign_jndi_provider_link.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_foreign_jndi_provider_link' }
       wlst template('puppet:///modules/orawls/providers/wls_foreign_jndi_provider_link/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_foreign_server.rb
+++ b/lib/puppet/type/wls_foreign_server.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_foreign_server' }
       wlst template('puppet:///modules/orawls/providers/wls_foreign_server/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_foreign_server_object.rb
+++ b/lib/puppet/type/wls_foreign_server_object.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_foreign_server_object' }
       wlst template('puppet:///modules/orawls/providers/wls_foreign_server_object/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_group.rb
+++ b/lib/puppet/type/wls_group.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_group' }
       wlst template('puppet:///modules/orawls/providers/wls_group/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_identity_asserter.rb
+++ b/lib/puppet/type/wls_identity_asserter.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_identity_asserter' }
       wlst template('puppet:///modules/orawls/providers/wls_identity_asserter/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jdbc_persistence_store.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jdbc_persistence_store' }
       wlst template('puppet:///modules/orawls/providers/wls_jdbc_persistence_store/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_bridge_destination.rb
+++ b/lib/puppet/type/wls_jms_bridge_destination.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_bridge_destination' }
 
       wlst template('puppet:///modules/orawls/providers/wls_jms_bridge_destination/index.py.erb', binding), environment

--- a/lib/puppet/type/wls_jms_connection_factory.rb
+++ b/lib/puppet/type/wls_jms_connection_factory.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_connection_factory' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_connection_factory/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_module.rb
+++ b/lib/puppet/type/wls_jms_module.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_module' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_module/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_queue.rb
+++ b/lib/puppet/type/wls_jms_queue.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_queue' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_queue/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_quota.rb
+++ b/lib/puppet/type/wls_jms_quota.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_quota' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_quota/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_security_policy.rb
+++ b/lib/puppet/type/wls_jms_security_policy.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_security_policy' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_security_policy/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_sort_destination_key.rb
+++ b/lib/puppet/type/wls_jms_sort_destination_key.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_quota' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_sort_destination_key/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_subdeployment.rb
+++ b/lib/puppet/type/wls_jms_subdeployment.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_subdeployment' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_subdeployment/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_template.rb
+++ b/lib/puppet/type/wls_jms_template.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_template' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_template/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jms_topic.rb
+++ b/lib/puppet/type/wls_jms_topic.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_topic' }
       wlst template('puppet:///modules/orawls/providers/wls_jms_topic/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_jmsserver.rb
+++ b/lib/puppet/type/wls_jmsserver.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jmsserver' }
       wlst template('puppet:///modules/orawls/providers/wls_jmsserver/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_machine.rb
+++ b/lib/puppet/type/wls_machine.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_machine' }
       wlst template('puppet:///modules/orawls/providers/wls_machine/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_mail_session.rb
+++ b/lib/puppet/type/wls_mail_session.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_mail_session' }
       wlst template('puppet:///modules/orawls/providers/wls_mail_session/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_messaging_bridge.rb
+++ b/lib/puppet/type/wls_messaging_bridge.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_jms_bridge_destination' }
 
       wlst template('puppet:///modules/orawls/providers/wls_messaging_bridge/index.py.erb', binding), environment

--- a/lib/puppet/type/wls_migratable_target.rb
+++ b/lib/puppet/type/wls_migratable_target.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_migratable_target' }
       wlst template('puppet:///modules/orawls/providers/wls_migratable_target/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_multi_datasource.rb
+++ b/lib/puppet/type/wls_multi_datasource.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_multi_datasource' }
 
       wlst template('puppet:///modules/orawls/providers/wls_multi_datasource/index.py.erb', binding), environment

--- a/lib/puppet/type/wls_resource_group.rb
+++ b/lib/puppet/type/wls_resource_group.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_resource_group' }
       wlst template('puppet:///modules/orawls/providers/wls_resource_group/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_resource_group_template.rb
+++ b/lib/puppet/type/wls_resource_group_template.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_resource_group_template' }
       wlst template('puppet:///modules/orawls/providers/wls_resource_group_template/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_resource_group_template_deployment.rb
+++ b/lib/puppet/type/wls_resource_group_template_deployment.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_resource_group_template_deployment' }
       wlst template('puppet:///modules/orawls/providers/wls_resource_group_template_deployment/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_role.rb
+++ b/lib/puppet/type/wls_role.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_role' }
       wlst template('puppet:///modules/orawls/providers/wls_role/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_saf_error_handler.rb
+++ b/lib/puppet/type/wls_saf_error_handler.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_saf_error_handler' }
       wlst template('puppet:///modules/orawls/providers/wls_saf_error_handler/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_saf_imported_destination.rb
+++ b/lib/puppet/type/wls_saf_imported_destination.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_saf_imported_destination' }
       wlst template('puppet:///modules/orawls/providers/wls_saf_imported_destination/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_saf_imported_destination_object.rb
+++ b/lib/puppet/type/wls_saf_imported_destination_object.rb
@@ -15,7 +15,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_saf_imported_destination_object' }
       wlst template('puppet:///modules/orawls/providers/wls_saf_imported_destination_object/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_saf_remote_context.rb
+++ b/lib/puppet/type/wls_saf_remote_context.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_saf_remote_context' }
       wlst template('puppet:///modules/orawls/providers/wls_saf_remote_context/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_safagent.rb
+++ b/lib/puppet/type/wls_safagent.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_safagent' }
       wlst template('puppet:///modules/orawls/providers/wls_safagent/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_server.rb
+++ b/lib/puppet/type/wls_server.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_server' }
       wlst template('puppet:///modules/orawls/providers/wls_server/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_server_channel.rb
+++ b/lib/puppet/type/wls_server_channel.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_server_channel' }
       wlst template('puppet:///modules/orawls/providers/wls_server_channel/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_server_template.rb
+++ b/lib/puppet/type/wls_server_template.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_server_template' }
       wlst template('puppet:///modules/orawls/providers/wls_server_template/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_server_tlog.rb
+++ b/lib/puppet/type/wls_server_tlog.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_server' }
       wlst template('puppet:///modules/orawls/providers/wls_server_tlog/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_singleton_service.rb
+++ b/lib/puppet/type/wls_singleton_service.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name}"
+      Puppet.debug "index #{name}"
       environment = { 'action' => 'index', 'type' => 'wls_singleton_service' }
       wlst template('puppet:///modules/orawls/providers/wls_singleton_service/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_user.rb
+++ b/lib/puppet/type/wls_user.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_user' }
       wlst template('puppet:///modules/orawls/providers/wls_user/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_virtual_host.rb
+++ b/lib/puppet/type/wls_virtual_host.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_virtual_host' }
       wlst template('puppet:///modules/orawls/providers/wls_virtual_host/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_virtual_target.rb
+++ b/lib/puppet/type/wls_virtual_target.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_virtual_target' }
       wlst template('puppet:///modules/orawls/providers/wls_virtual_target/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_workmanager.rb
+++ b/lib/puppet/type/wls_workmanager.rb
@@ -13,7 +13,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_workmanager' }
       wlst template('puppet:///modules/orawls/providers/wls_workmanager/index.py.erb', binding), environment
     end

--- a/lib/puppet/type/wls_workmanager_constraint.rb
+++ b/lib/puppet/type/wls_workmanager_constraint.rb
@@ -14,7 +14,7 @@ module Puppet
     set_command(:wlst)
 
     to_get_raw_resources do
-      Puppet.info "index #{name} "
+      Puppet.debug "index #{name} "
       environment = { 'action' => 'index', 'type' => 'wls_workmanager_constraint' }
       wlst template('puppet:///modules/orawls/providers/wls_workmanager_constraint/index.py.erb', binding), environment
     end


### PR DESCRIPTION
I've set all Puppet.info logging for Index functions in resource types to Puppet.debug to cleanup puppet run logging.