### PR TITLE
Modified Puppet.info -> Puppet.debug for puppet run log cleanup

### DIFF
--- a/lib/puppet/provider/opatch/opatch.rb
+++ b/lib/puppet/provider/opatch/opatch.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:opatch).provide(:opatch) do
     su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
 
     output = `su #{su_shell} - #{user} -c '#{command}'`
-    Puppet.info "opatch result: #{output}"
+    Puppet.debug "opatch result: #{output}"
 
     result = false
     output.each_line do |li|

--- a/lib/puppet/provider/wls_opatch/prefetching.rb
+++ b/lib/puppet/provider/wls_opatch/prefetching.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
     os_user                 = resource[:os_user]
     full_command            = "#{oracle_product_home_dir}/OPatch/opatch #{command} -oh #{oracle_product_home_dir} #{jre_specfied} #{orainst}"
     output = Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
-    Puppet.info output
+    Puppet.debug output
     output
   end
 
@@ -40,7 +40,7 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
   def self.patches_in_home(oracle_product_home_dir, os_user, orainst_dir)
     full_command  = "#{oracle_product_home_dir}/OPatch/opatch lsinventory -oh #{oracle_product_home_dir} -invPtrLoc #{orainst_dir}/oraInst.loc"
     raw_list = Puppet::Util::Execution.execute(full_command, :failonfail => true, :uid => os_user)
-    Puppet.info raw_list
+    Puppet.debug raw_list
     patch_ids = raw_list.scan(/Patch\s.(\d+)\s.*:\sapplied on/).flatten
     patch_ids.collect{|p| "#{oracle_product_home_dir}:#{p}"}
   end

--- a/lib/utils/wls_access.rb
+++ b/lib/utils/wls_access.rb
@@ -31,7 +31,7 @@ module Utils
 
       wls_type = 'wlst'
       domains.each do |key, domainValues|
-        Puppet.info "domain found #{key}"
+        Puppet.debug "domain found #{key}"
         wls_type = 'rest' if domainValues['connect_url'].include? "http"
       end
 
@@ -42,7 +42,7 @@ module Utils
           i = 1
           csv_string = ''
           domains.each do |key, domainValues|
-            Puppet.info "domain found #{key}"
+            Puppet.debug "domain found #{key}"
             result = wlst2 content, action, key, domains[key], parameters
             if i > 1
               # with multi domain, remove first line if it is a header
@@ -62,7 +62,7 @@ module Utils
           # if index do all domains
           all_items = []
           domains.each do |key, domainValues|
-            Puppet.info "domain found #{key}"
+            Puppet.debug "domain found #{key}"
             result = rest action, key, domains[key], parameters
             all_items.concat result
           end
@@ -84,7 +84,7 @@ module Utils
         weblogicPassword   = domain_values['weblogic_password']
 
         uri_string = "#{weblogicConnectUrl}#{parameters['rest_url']}"
-        Puppet.info uri_string
+        Puppet.debug uri_string
 
         uri = URI.parse(uri_string)
 
@@ -152,7 +152,7 @@ module Utils
       action = ''
       unless parameters.nil?
         action = parameters['action']
-        Puppet.info "Executing: #{script} with action #{action}"
+        Puppet.debug "Executing: #{script} with action #{action}"
       else
         Puppet.info "Executing: #{script} for a create,modify or destroy"
       end
@@ -170,7 +170,7 @@ module Utils
         # if index do all domains
         i = 1
         domains.each do |key, values|
-          Puppet.info "domain found #{key}"
+          Puppet.debug "domain found #{key}"
           csv_domain_string = execute_wlst(script, tmpFile, parameters, key, values, :return_output => true)
           if i > 1
             # with multi domain, remove first line if it is a header


### PR DESCRIPTION
More Puppet.info changes to Puppet.debug.

I've modified the opatch class to never log to info anymore, this might be improved to an if statement that it only logs when it's executing an actual OPatch installer.

The current code logs an lsinventory command on every run, which clutters the log.