### PR TITLE
Add extra java parameter to node manager

### DIFF
--- a/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
+++ b/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
@@ -21,14 +21,15 @@ Puppet::Type.type(:wls_adminserver).provide(:wls_adminserver) do
     custom_trust                = resource[:custom_trust]
     trust_keystore_file         = resource[:trust_keystore_file]
     trust_keystore_passphrase   = resource[:trust_keystore_passphrase]
+    extra_arguments             = resource[:extra_arguments]
     ohs_standalone_server       = resource[:ohs_standalone_server]
 
     Puppet.debug "adminserver custom trust: #{custom_trust}"
 
     if "#{custom_trust}" == 'true'
-      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} -Dweblogic.security.TrustKeyStore=CustomTrust -Dweblogic.security.CustomTrustKeyStoreFileName=#{trust_keystore_file} -Dweblogic.security.CustomTrustKeystorePassPhrase=#{trust_keystore_passphrase}"
+      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} -Dweblogic.security.TrustKeyStore=CustomTrust -Dweblogic.security.CustomTrustKeyStoreFileName=#{trust_keystore_file} -Dweblogic.security.CustomTrustKeystorePassPhrase=#{trust_keystore_passphrase} #{extra_arguments}"
     else
-      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled}"
+      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} #{extra_arguments}"
     end
 
     if "#{ohs_standalone_server}" == 'true'

--- a/lib/puppet/type/wls_adminserver.rb
+++ b/lib/puppet/type/wls_adminserver.rb
@@ -154,6 +154,13 @@ module Puppet
 
     end
 
+    newparam(:extra_arguments) do
+      desc <<-EOT
+        The extra java argument like -Dweblogic.security.SSL.minimumProtocolVersion=TLSv1.
+      EOT
+
+    end
+
     newparam(:refreshonly) do
       desc <<-EOT
         The command should only be run as a

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -26,6 +26,7 @@ define orawls::control (
   $custom_trust                = hiera('wls_custom_trust'              , false),
   $trust_keystore_file         = hiera('wls_trust_keystore_file'       , undef),
   $trust_keystore_passphrase   = hiera('wls_trust_keystore_passphrase' , undef),
+  $extra_arguments             = '', # '-Dweblogic.security.SSL.minimumProtocolVersion=TLSv1',
   $os_user                     = hiera('wls_os_user'), # oracle
   $os_group                    = hiera('wls_os_group'), # dba
   $download_dir                = hiera('wls_download_dir'), # /data/install
@@ -60,6 +61,7 @@ define orawls::control (
       custom_trust                => $custom_trust,
       trust_keystore_file         => $trust_keystore_file,
       trust_keystore_passphrase   => $trust_keystore_passphrase,
+      extra_arguments             => $extra_arguments,
       ohs_standalone_server       => $ohs_standalone_server,
     }
   }

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -18,6 +18,7 @@ define orawls::nodemanager (
   $custom_identity_keystore_passphrase   = undef,
   $custom_identity_alias                 = undef,
   $custom_identity_privatekey_passphrase = undef,
+  $extra_arguments                       = '', # '-Dweblogic.security.SSL.minimumProtocolVersion=TLSv1'
   $wls_domains_dir                       = hiera('wls_domains_dir'               , undef),
   $domain_name                           = hiera('domain_name'                   , undef),
   $jdk_home_dir                          = hiera('wls_jdk_home_dir'), # /usr/java/jdk1.7.0_45
@@ -191,9 +192,9 @@ define orawls::nodemanager (
   }
 
   if $jsse_enabled == true {
-    $env = "JAVA_OPTIONS=-Dweblogic.ssl.JSSEEnabled=true -Dweblogic.security.SSL.enableJSSE=true ${trust_env}"
+    $env = "JAVA_OPTIONS=-Dweblogic.ssl.JSSEEnabled=true -Dweblogic.security.SSL.enableJSSE=true ${trust_env} ${extra_arguments}"
   } else {
-    $env = "JAVA_OPTIONS=-Dweblogic.ssl.JSSEEnabled=false -Dweblogic.security.SSL.enableJSSE=false ${trust_env}"
+    $env = "JAVA_OPTIONS=-Dweblogic.ssl.JSSEEnabled=false -Dweblogic.security.SSL.enableJSSE=false ${trust_env} ${extra_arguments}"
   }
 
   exec { "startNodemanager ${title}":


### PR DESCRIPTION
See https://github.com/biemond/biemond-orawls/issues/356

Also adding the extra parameter to start wls admin.
Info: adminserver action: start with command
/opt/wls/middleware11g/wlserver_10.3/common/bin/wlst.sh
-skipWLSModuleScanning <<-EOF
nmConnect("weblogic","xxxxx","192.168.234.95",5556,"soa_domain","/opt/wl
s/wlsdomains/domains/soa_domain","ssl")
nmStart("AdminServer")
nmDisconnect()
EOF and CONFIG_JVM_ARGS=-Dweblogic.ssl.JSSEEnabled=true
-Dweblogic.security.SSL.enableJSSE=true
-Dweblogic.security.TrustKeyStore=CustomTrust
-Dweblogic.security.CustomTrustKeyStoreFileName=/opt/ssl/keystore/trusts
tore.jks -Dweblogic.security.CustomTrustKeystorePassPhrase=welcome
-Dweblogic.security.SSL.minimumProtocolVersion=TLSv1
Info: adminserver result: