### PR TITLE
Various updates for non-root support

### DIFF
--- a/lib/facter/orawls.rb
+++ b/lib/facter/orawls.rb
@@ -17,7 +17,7 @@ end
 def get_ora_inventory_path
   os = Facter.value(:kernel)
   if 'Linux' == os
-    ora_inventory_path = Facter.value('override_oraInstPath')
+    ora_inventory_path = Facter.value('override_orainst_dir')
     if ora_inventory_path.nil?
       Puppet.debug 'ora_inventory_path is default to /etc'
       return '/etc'

--- a/lib/facter/orawls.rb
+++ b/lib/facter/orawls.rb
@@ -17,7 +17,14 @@ end
 def get_ora_inventory_path
   os = Facter.value(:kernel)
   if 'Linux' == os
-    return '/etc'
+    ora_inventory_path = Facter.value('override_oraInstPath')
+    if ora_inventory_path.nil?
+      Puppet.debug 'ora_inventory_path is default to /etc'
+      return '/etc'
+    else
+      Puppet.debug "ora_inventory_path is overridden to #{ora_inventory_path}"
+      return ora_inventory_path
+    end
   elsif 'SunOS' == os
     return '/var/opt/oracle'
   end

--- a/lib/puppet/provider/wls_rcu/wls_rcu.rb
+++ b/lib/puppet/provider/wls_rcu/wls_rcu.rb
@@ -15,7 +15,11 @@ Puppet::Type.type(:wls_rcu).provide(:wls_rcu) do
     kernel = Facter.value(:kernel)
     su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
 
-    output = `su #{su_shell} - #{user} -c 'export JAVA_HOME=#{jdk_home_dir};export TZ=GMT;export LANG=en_US.UTF8;export LC_ALL=en_US.UTF8;export NLS_LANG=american_america;#{statement}'`
+    if Puppet.features.root?
+      output = `su #{su_shell} - #{user} -c 'export JAVA_HOME=#{jdk_home_dir};export TZ=GMT;export LANG=en_US.UTF8;export LC_ALL=en_US.UTF8;export NLS_LANG=american_america;#{statement}'`
+    else
+      output = `export JAVA_HOME=#{jdk_home_dir};export TZ=GMT;export LANG=en_US.UTF8;export LC_ALL=en_US.UTF8;export NLS_LANG=american_america;#{statement}`
+    end
     Puppet.info "RCU result: #{output}"
 
     # Check for 'Repository Creation Utility - Create : Operation Completed' else raise
@@ -47,7 +51,13 @@ Puppet::Type.type(:wls_rcu).provide(:wls_rcu) do
     kernel = Facter.value(:kernel)
     su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
 
-    rcu_output = `su #{su_shell} - #{user} -c 'export TZ=GMT;#{oraclehome}/common/bin/wlst.sh #{checkscript} #{jdbcurl} #{syspassword} #{prefix} #{sysuser}'`
+    if Puppet.features.root?
+      #output = `su #{su_shell} - #{user} -c 'export JAVA_HOME=#{jdk_home_dir};export TZ=GMT;export LANG=en_US.UTF8;export LC_ALL=en_US.UTF8;export NLS_LANG=american_america;#{statement}'`
+      rcu_output = `su #{su_shell} - #{user} -c 'export TZ=GMT;#{oraclehome}/common/bin/wlst.sh #{checkscript} #{jdbcurl} #{syspassword} #{prefix} #{sysuser}'`
+    else
+      rcu_output = `export TZ=GMT;#{oraclehome}/common/bin/wlst.sh #{checkscript} #{jdbcurl} #{syspassword} #{prefix} #{sysuser}`
+      #output = `'export JAVA_HOME=#{jdk_home_dir};export TZ=GMT;export LANG=en_US.UTF8;export LC_ALL=en_US.UTF8;export NLS_LANG=american_america;#{statement}'`
+    end
     fail ArgumentError, "Error executing puppet code, #{rcu_output}" if $CHILD_STATUS != 0
     Puppet.info "RCU check result: #{rcu_output}"
     rcu_output.each_line do |li|

--- a/lib/puppet/type/wls_opatch.rb
+++ b/lib/puppet/type/wls_opatch.rb
@@ -69,8 +69,14 @@ module Puppet
       Puppet.info "Unzipping source #{source} to #{output}"
       environment = {}
       environment[:PATH] = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
-      Puppet::Util::Execution.execute("unzip -o #{file} -d #{output}", :failonfail => true, :uid => os_user, :custom_environment => environment )
-      Puppet.info "Done Unzipping source #{source} to #{output}"
+      kernel = Facter.value(:kernel)
+      su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
+      Puppet.info "Done Unzipping source #{source} to #{output}"  
+      if Puppet.features.root?
+        Puppet::Util::Execution.execute("unzip -o #{file} -d #{output}", :failonfail => true, :uid => os_user, :custom_environment => environment )
+      else
+        `unzip -o #{file} -d #{output}`
+      end
       "#{output}/#{patch_id}"
     end
 

--- a/manifests/copydomain.pp
+++ b/manifests/copydomain.pp
@@ -26,7 +26,7 @@ define orawls::copydomain (
   $log_output                 = false, # true|false
   $server_start_mode          = 'dev', # dev/prod
   $wls_domains_file           = hiera('wls_domains_file'          , undef),
-  $puppet_os_user             = hiera('wls_os_user','root'),
+  $puppet_os_user             = hiera('puppet_os_user','root'),
   $jsse_enabled               = hiera('wls_jsse_enabled'              , false),
   $custom_trust               = hiera('wls_custom_trust'              , false),
   $trust_keystore_file        = hiera('wls_trust_keystore_file'       , undef),
@@ -187,7 +187,7 @@ define orawls::copydomain (
 
     exec { "unpack ${domain_name}":
       command     => "${bin_dir} ${unPackCommand} -user_name=${weblogic_user} -password=${weblogic_password}",
-      environment => ["JAVA_HOME=${jdk_home_dir}","CLASSPATH=$managedserver_classpath"],
+      environment => ["JAVA_HOME=${jdk_home_dir}"],
       path        => $exec_path,
       user        => $os_user,
       group       => $os_group,

--- a/manifests/copydomain.pp
+++ b/manifests/copydomain.pp
@@ -25,8 +25,8 @@ define orawls::copydomain (
   $log_dir                    = hiera('wls_log_dir'               , undef), # /data/logs
   $log_output                 = false, # true|false
   $server_start_mode          = 'dev', # dev/prod
-  $wls_domains_file           = undef,
-  $puppet_os_user             = 'root',
+  $wls_domains_file           = hiera('wls_domains_file'          , undef),
+  $puppet_os_user             = hiera('wls_os_user','root'),
   $jsse_enabled               = hiera('wls_jsse_enabled'              , false),
   $custom_trust               = hiera('wls_custom_trust'              , false),
   $trust_keystore_file        = hiera('wls_trust_keystore_file'       , undef),
@@ -187,7 +187,7 @@ define orawls::copydomain (
 
     exec { "unpack ${domain_name}":
       command     => "${bin_dir} ${unPackCommand} -user_name=${weblogic_user} -password=${weblogic_password}",
-      environment => ["JAVA_HOME=${jdk_home_dir}"],
+      environment => ["JAVA_HOME=${jdk_home_dir}","CLASSPATH=$managedserver_classpath"],
       path        => $exec_path,
       user        => $os_user,
       group       => $os_group,

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -57,7 +57,7 @@ define orawls::domain (
   $ohs_standalone_listen_port            = undef,
   $ohs_standalone_ssl_listen_port        = undef,
   $wls_domains_file                      = hiera('wls_domains_file'          , undef),
-  $puppet_os_user                        = hiera('wls_os_user','root'),
+  $puppet_os_user                        = hiera('puppet_os_user','root'),
 )
 {
   if ( $wls_domains_file == undef or $wls_domains_file == '' ){

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -56,8 +56,8 @@ define orawls::domain (
   $ohs_standalone_listen_address         = undef,
   $ohs_standalone_listen_port            = undef,
   $ohs_standalone_ssl_listen_port        = undef,
-  $wls_domains_file                      = undef,
-  $puppet_os_user                        = 'root',
+  $wls_domains_file                      = hiera('wls_domains_file'          , undef),
+  $puppet_os_user                        = hiera('wls_os_user','root'),
 )
 {
   if ( $wls_domains_file == undef or $wls_domains_file == '' ){

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -44,7 +44,6 @@ define orawls::fmw(
       } else {
         $oraInstPath = $orainstpath_dir
       }
-      
       case $::architecture {
         'i386': {
           $installDir = 'linux'

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -26,6 +26,7 @@ define orawls::fmw(
   $temp_directory       = hiera('wls_temp_dir','/tmp'),      # /tmp directory
   $ohs_mode             = hiera('ohs_mode', 'collocated'),
   $oracle_inventory_dir = undef,
+  $oraInstPath_location = hiera('oraInstPath_location', undef),
 )
 {
   $exec_path    = "${jdk_home_dir}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:"
@@ -38,7 +39,12 @@ define orawls::fmw(
 
   case $::kernel {
     'Linux': {
-      $oraInstPath = '/etc'
+      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+        $oraInstPath = '/etc'
+      } else {
+        $oraInstPath = $oraInstPath_location
+      }
+      
       case $::architecture {
         'i386': {
           $installDir = 'linux'
@@ -495,6 +501,7 @@ define orawls::fmw(
       path      => $exec_path,
       user      => $os_user,
       group     => $os_group,
+      timeout   => 0,
       cwd       => $temp_directory,
       logoutput => false,
       require   => Orawls::Utils::Orainst["create oraInst for ${name}"],
@@ -528,6 +535,7 @@ define orawls::fmw(
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
+        timeout   => 0,
         cwd       => $temp_directory,
         logoutput => false,
         require   => Exec["extract ${fmw_file1} for ${name}"],
@@ -561,6 +569,7 @@ define orawls::fmw(
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
+        timeout   => 0,
         cwd       => $temp_directory,
         logoutput => false,
         require   => Exec["extract ${fmw_file2} for ${name}"],
@@ -594,6 +603,7 @@ define orawls::fmw(
         path      => $exec_path,
         user      => $os_user,
         group     => $os_group,
+        timeout   => 0,
         cwd       => $temp_directory,
         logoutput => false,
         require   => Exec["extract ${fmw_file3} for ${name}"],

--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -26,7 +26,7 @@ define orawls::fmw(
   $temp_directory       = hiera('wls_temp_dir','/tmp'),      # /tmp directory
   $ohs_mode             = hiera('ohs_mode', 'collocated'),
   $oracle_inventory_dir = undef,
-  $oraInstPath_location = hiera('oraInstPath_location', undef),
+  $orainstpath_dir      = hiera('orainstpath_dir', undef),
 )
 {
   $exec_path    = "${jdk_home_dir}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:"
@@ -39,10 +39,10 @@ define orawls::fmw(
 
   case $::kernel {
     'Linux': {
-      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+      if ( $orainstpath_dir == undef or $orainstpath_dir == '' ){
         $oraInstPath = '/etc'
       } else {
-        $oraInstPath = $oraInstPath_location
+        $oraInstPath = $orainstpath_dir
       }
       
       case $::architecture {

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -31,7 +31,7 @@ define orawls::nodemanager (
   $sleep                                 = hiera('wls_nodemanager_sleep'         , 20), # default sleep time
   $properties                            = {},
   $ohs_standalone                        = false,
-  $puppet_os_user                        = hiera('wls_os_user','root'),
+  $puppet_os_user                        = hiera('puppet_os_user','root'),
 )
 {
 

--- a/manifests/nodemanager.pp
+++ b/manifests/nodemanager.pp
@@ -31,7 +31,7 @@ define orawls::nodemanager (
   $sleep                                 = hiera('wls_nodemanager_sleep'         , 20), # default sleep time
   $properties                            = {},
   $ohs_standalone                        = false,
-  $puppet_os_user                        = 'root',
+  $puppet_os_user                        = hiera('wls_os_user','root'),
 )
 {
 

--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -15,6 +15,7 @@ define orawls::opatch(
   $source                  = hiera('wls_source', undef), # puppet:///modules/orawls/ | /mnt | /vagrant
   $remote_file             = true,  # true|false
   $log_output              = false, # true|false
+  $oraInstPath_location    = hiera('oraInstPath_location', undef),
 )
 {
   # $exec_path = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
@@ -59,7 +60,11 @@ define orawls::opatch(
 
   case $::kernel {
     'Linux': {
-      $oraInstPath = '/etc'
+      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+        $oraInstPath = '/etc'
+      } else {
+        $oraInstPath = $oraInstPath_location
+      }
     }
     'SunOS': {
       $oraInstPath = '/var/opt/oracle'
@@ -89,4 +94,3 @@ define orawls::opatch(
   # }
 
 }
-

--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -15,7 +15,7 @@ define orawls::opatch(
   $source                  = hiera('wls_source', undef), # puppet:///modules/orawls/ | /mnt | /vagrant
   $remote_file             = true,  # true|false
   $log_output              = false, # true|false
-  $oraInstPath_location    = hiera('oraInstPath_location', undef),
+  $orainstpath_dir         = hiera('orainstpath_dir', undef),
 )
 {
   # $exec_path = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:'
@@ -60,10 +60,10 @@ define orawls::opatch(
 
   case $::kernel {
     'Linux': {
-      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+      if ( $orainstpath_dir == undef or $orainstpath_dir == '' ){
         $oraInstPath = '/etc'
       } else {
-        $oraInstPath = $oraInstPath_location
+        $oraInstPath = $orainstpath_dir
       }
     }
     'SunOS': {

--- a/manifests/utils/orainst.pp
+++ b/manifests/utils/orainst.pp
@@ -8,15 +8,15 @@ define orawls::utils::orainst
 (
   $ora_inventory_dir = undef,
   $os_group          = undef,
-  $oraInstPath_location = hiera('oraInstPath_location', undef),
+  $orainstpath_dir   = hiera('orainstpath_dir', undef),
 )
 {
   case $::kernel {
     'Linux': {
-      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+      if ( $orainstpath_dir == undef or $orainstpath_dir == '' ){
         $oraInstPath = '/etc'
       } else {
-        $oraInstPath = $oraInstPath_location
+        $oraInstPath = $orainstpath_dir
       }
     }
     'SunOS': {

--- a/manifests/utils/orainst.pp
+++ b/manifests/utils/orainst.pp
@@ -8,11 +8,16 @@ define orawls::utils::orainst
 (
   $ora_inventory_dir = undef,
   $os_group          = undef,
+  $oraInstPath_location = hiera('oraInstPath_location', undef),
 )
 {
   case $::kernel {
     'Linux': {
-      $oraInstPath        = '/etc'
+      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+        $oraInstPath = '/etc'
+      } else {
+        $oraInstPath = $oraInstPath_location
+      }
     }
     'SunOS': {
       $oraInstPath        = '/var/opt/oracle'

--- a/manifests/weblogic_type.pp
+++ b/manifests/weblogic_type.pp
@@ -18,7 +18,7 @@ define orawls::weblogic_type (
   $java_parameters      = '',    # '-Dspace.detection=false'
   $log_output           = false, # true|false
   $temp_directory       = '/tmp',# /tmp temporay directory for files extractions
-  $oraInstPath_location = hiera('oraInstPath_location', undef),
+  $orainstpath_dir      = hiera('orainstpath_dir', undef),
 ) {
 
   # check required parameters
@@ -73,10 +73,10 @@ define orawls::weblogic_type (
 
   case $::kernel {
     'Linux': {
-      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+      if ( $orainstpath_dir == undef or $orainstpath_dir == '' ){
         $oraInstPath = '/etc'
       } else {
-        $oraInstPath = $oraInstPath_location
+        $oraInstPath = $orainstpath_dir
       }
       $java_statement     = "java ${java_parameters}"
     }
@@ -221,4 +221,3 @@ define orawls::weblogic_type (
     }
   }
 }
-

--- a/manifests/weblogic_type.pp
+++ b/manifests/weblogic_type.pp
@@ -18,6 +18,7 @@ define orawls::weblogic_type (
   $java_parameters      = '',    # '-Dspace.detection=false'
   $log_output           = false, # true|false
   $temp_directory       = '/tmp',# /tmp temporay directory for files extractions
+  $oraInstPath_location = hiera('oraInstPath_location', undef),
 ) {
 
   # check required parameters
@@ -72,7 +73,11 @@ define orawls::weblogic_type (
 
   case $::kernel {
     'Linux': {
-      $oraInstPath        = '/etc'
+      if ( $oraInstPath_location == undef or $oraInstPath_location == '' ){
+        $oraInstPath = '/etc'
+      } else {
+        $oraInstPath = $oraInstPath_location
+      }
       $java_statement     = "java ${java_parameters}"
     }
     'SunOS': {


### PR DESCRIPTION
*alternative /etc/oraInst.loc location can be set through by adding facter “override_oraInstPath” and hiera value oraInstPath_location. ora_wls manifests updated to use new location if defined.
*rcu updated so it doesn’t try to switch to root then to os_ouser when running as non root
*opatch unzip updated so it doesn’t try to switch to root then to os_ouser when running as non root

This should now fully certify orawls to run as non root