### PR TITLE
Fix ordering of `rm nodemanager.properties`

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -608,6 +608,9 @@ define orawls::domain (
         group   => $os_group,
         require => Exec["execwlst ${domain_name} ${title}"],
       }
+      if $extensionsTemplateFile {
+        Exec["execwlst ${domain_name} extension ${title}"] -> Exec["rm ${domain_name} nodemanager.properties"]
+      }
     }
 
     yaml_setting { "domain ${title}":


### PR DESCRIPTION
This needs to happen after the extension template too, (if one is being
used).

Before this change, in my environment, the `nodemanager.properties` file was getting deleted before the extension template was run.  The `Exec["execwlst ${domain_name} extension ${title}"]` would result in a new `nodemanager.properties` being created and with `replace => false` this was never being written with the correct values in `nodemanager.pp`.  In my case, the puppet run would fail because the listenaddress of the node manager was incorrect.