### PR TITLE
Add `adminserver_use_ssl` to `wls_managedserver`

### DIFF
--- a/lib/puppet/provider/wls_managedserver/wls_managedserver.rb
+++ b/lib/puppet/provider/wls_managedserver/wls_managedserver.rb
@@ -7,14 +7,15 @@ Puppet::Type.type(:wls_managedserver).provide(:wls_managedserver) do
   def managedserver_control(action)
     Puppet.debug "managedserver action: #{action}"
 
-    target                    = resource[:target]
-    name                      = resource[:server_name]
-    user                      = resource[:os_user]
-    weblogic_home_dir         = resource[:weblogic_home_dir]
-    weblogic_user             = resource[:weblogic_user]
-    weblogic_password         = resource[:weblogic_password]
-    adminserver_address       = resource[:adminserver_address]
-    adminserver_port          = resource[:adminserver_port]
+    target                      = resource[:target]
+    name                        = resource[:server_name]
+    user                        = resource[:os_user]
+    weblogic_home_dir           = resource[:weblogic_home_dir]
+    weblogic_user               = resource[:weblogic_user]
+    weblogic_password           = resource[:weblogic_password]
+    adminserver_address         = resource[:adminserver_address]
+    adminserver_port            = resource[:adminserver_port]
+    adminserver_secure_listener = resource[:adminserver_secure_listener]
 
     if action == :start
       wls_action = "start(\"#{name}\",\"#{target}\")"
@@ -22,8 +23,15 @@ Puppet::Type.type(:wls_managedserver).provide(:wls_managedserver) do
       wls_action = "shutdown(\"#{name}\",\"#{target}\",force=\"true\")"
     end
 
+    protocol = case adminserver_secure_listener
+               when :true
+                 't3s'
+               else
+                 't3'
+               end
+
     command = "#{weblogic_home_dir}/common/bin/wlst.sh -skipWLSModuleScanning <<-EOF
-connect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"t3://#{adminserver_address}:#{adminserver_port}\")
+connect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"#{protocol}://#{adminserver_address}:#{adminserver_port}\")
 try:
     #{wls_action}
 except:
@@ -52,15 +60,16 @@ EOF"
   end
 
   def managedserver_status
-    domain_name         = resource[:domain_name]
-    name                = resource[:server_name]
-    target              = resource[:target]
-    user                = resource[:os_user]
-    weblogic_home_dir   = resource[:weblogic_home_dir]
-    weblogic_user       = resource[:weblogic_user]
-    weblogic_password   = resource[:weblogic_password]
-    adminserver_address = resource[:adminserver_address]
-    adminserver_port    = resource[:adminserver_port]
+    domain_name                 = resource[:domain_name]
+    name                        = resource[:server_name]
+    target                      = resource[:target]
+    user                        = resource[:os_user]
+    weblogic_home_dir           = resource[:weblogic_home_dir]
+    weblogic_user               = resource[:weblogic_user]
+    weblogic_password           = resource[:weblogic_password]
+    adminserver_address         = resource[:adminserver_address]
+    adminserver_port            = resource[:adminserver_port]
+    adminserver_secure_listener = resource[:adminserver_secure_listener]
 
     kernel = Facter.value(:kernel)
 
@@ -81,8 +90,15 @@ EOF"
     #   end
     # end
 
+    protocol = case adminserver_secure_listener
+               when :true
+                 't3s'
+               else
+                 't3'
+               end
+
     command = "#{weblogic_home_dir}/common/bin/wlst.sh -skipWLSModuleScanning <<-EOF
-connect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"t3://#{adminserver_address}:#{adminserver_port}\")
+connect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"#{protocol}://#{adminserver_address}:#{adminserver_port}\")
 state(\"#{name}\",\"#{target}\")
 exit()
 EOF"

--- a/lib/puppet/type/wls_managedserver.rb
+++ b/lib/puppet/type/wls_managedserver.rb
@@ -103,6 +103,16 @@ module Puppet
       EOT
     end
 
+    newparam(:adminserver_secure_listener ) do
+      desc <<-EOT
+        Whether to use ssl (t3s) when connecting to the admin server
+      EOT
+
+      newvalues(:true, :false)
+
+      defaultto :false
+    end
+
     newparam(:refreshonly) do
       desc <<-EOT
         The command should only be run as a
@@ -118,6 +128,5 @@ module Puppet
       Puppet.info 'wls_managedserver refresh'
       provider.restart
     end
-
   end
 end

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -17,6 +17,7 @@ define orawls::control (
   $server                      = 'AdminServer',
   $adminserver_address         = hiera('domain_adminserver_address'    , 'localhost'),
   $adminserver_port            = hiera('domain_adminserver_port'       , 7001),
+  $adminserver_secure_listener = false,
   $nodemanager_secure_listener = true,
   $nodemanager_port            = hiera('domain_nodemanager_port'       , 5556),
   $action                      = 'start', # start|stop
@@ -67,17 +68,18 @@ define orawls::control (
   }
   else {
     wls_managedserver{"${title}:Server":
-      ensure              => $action,   #running|start|abort|stop
-      target              => $target,
-      server_name         => $server,
-      domain_name         => $domain_name,
-      os_user             => $os_user,
-      weblogic_home_dir   => $weblogic_home_dir,
-      weblogic_user       => $weblogic_user,
-      weblogic_password   => $weblogic_password,
-      jdk_home_dir        => $jdk_home_dir,
-      adminserver_address => $adminserver_address,
-      adminserver_port    => $adminserver_port,
+      ensure                      => $action,   #running|start|abort|stop
+      target                      => $target,
+      server_name                 => $server,
+      domain_name                 => $domain_name,
+      os_user                     => $os_user,
+      weblogic_home_dir           => $weblogic_home_dir,
+      weblogic_user               => $weblogic_user,
+      weblogic_password           => $weblogic_password,
+      jdk_home_dir                => $jdk_home_dir,
+      adminserver_address         => $adminserver_address,
+      adminserver_port            => $adminserver_port,
+      adminserver_secure_listener => $adminserver_secure_listener,
     }
   }
 }


### PR DESCRIPTION
New parameter defaults to `false`.  When `true`, changes the protocol
used from `t3` to `t3s`.

Fixes
```
javax.naming.CommunicationException: [Login failed for an unknown reason: P]
```
when trying to start a managed server when ssl is enabled on the admin
server.