### PR TITLE
Create wls ohsserver type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -93,6 +93,7 @@ This will use WLST to retrieve the current state and to the changes. With WebLog
 - [wls_setting](#wls_setting), set the default wls parameters for the other types and also used by puppet resource
 - [wls_adminserver](#wls_adminserver) control the adminserver or subscribe to changes
 - [wls_managedserver](#wls_managedserver) control the managed server,cluster or subscribe to changes
+- [wls_ohsserver](#wls_ohsserver) control the ohs standalone server or subscribe to changes
 - [wls_domain](#wls_domain)
 - [wls_deployment](#wls_deployment)
 - [wls_domain](#wls_domain)
@@ -1403,7 +1404,7 @@ here is an overview of all the parameters you can set with its defaults
 
 
 ### control
-__orawls::control__ start or stops the AdminServer,Managed Server or a Cluster of a WebLogic Domain, this will call the wls_managedserver and wls_adminserver types
+__orawls::control__ start or stops the AdminServer,Managed Server, OHS Standalone Server or a Cluster of a WebLogic Domain, this will call the wls_managedserver, wls_adminserver and wls_ohsserver types
 
     orawls::control{'startWLSAdminServer12c':
       domain_name                 => "Wls12c",
@@ -2300,6 +2301,28 @@ subscribe to a wls_domain, wls_identity_asserter or wls_authenticaton_provider e
       subscribe                 => Wls_domain['Wls1036'],
     }
 
+### wls_ohsserver
+
+type for ohs server control like start, running, abort and stop.
+also supports subscribe with refreshonly
+
+
+    # for this type you won't need a wls_setting identifier
+    wls_ohsserver{'OHS Server:':
+      ensure                    => 'running',   #running|start|abort|stop
+      server_name               => hiera('domain_adminserver'),
+      domain_name               => hiera('domain_name'),
+      domain_path               => "/opt/oracle/wlsdomains/domains/Wls1036",
+      os_user                   => hiera('wls_os_user'),
+      weblogic_home_dir         => hiera('wls_weblogic_home_dir'),
+      weblogic_user             => hiera('wls_weblogic_user'),
+      weblogic_password         => hiera('domain_wls_password'),
+      jdk_home_dir              => hiera('wls_jdk_home_dir'),
+      nodemanager_address       => hiera('domain_adminserver_address'),
+      nodemanager_port          => hiera('domain_nodemanager_port'),
+      jsse_enabled              => false,
+      custom_trust              => false,
+    }
 
 ### wls_deployment
 

--- a/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
+++ b/lib/puppet/provider/wls_adminserver/wls_adminserver.rb
@@ -22,7 +22,6 @@ Puppet::Type.type(:wls_adminserver).provide(:wls_adminserver) do
     trust_keystore_file         = resource[:trust_keystore_file]
     trust_keystore_passphrase   = resource[:trust_keystore_passphrase]
     extra_arguments             = resource[:extra_arguments]
-    ohs_standalone_server       = resource[:ohs_standalone_server]
 
     Puppet.debug "adminserver custom trust: #{custom_trust}"
 
@@ -32,24 +31,12 @@ Puppet::Type.type(:wls_adminserver).provide(:wls_adminserver) do
       config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} #{extra_arguments}"
     end
 
-    if "#{ohs_standalone_server}" == 'true'
-      base_path = "#{weblogic_home_dir}/../oracle_common"
-    else
-      base_path = weblogic_home_dir
-    end
+    base_path = weblogic_home_dir
 
     if action == :start
-      if "#{ohs_standalone_server}" == 'true'
-        wls_action = "nmStart(serverName=\"#{name}\", serverType=\"OHS\")"
-      else
-        wls_action = "nmStart(\"#{name}\")"
-      end
+      wls_action = "nmStart(\"#{name}\")"
     else
-      if "#{ohs_standalone_server}" == 'true'
-        wls_action = "nmKill(serverName=\"#{name}\", serverType=\"OHS\")"
-      else
-        wls_action = "nmKill(\"#{name}\")"
-      end
+      wls_action = "nmKill(\"#{name}\")"
     end
 
     if "#{nodemanager_secure_listener}" == 'true'

--- a/lib/puppet/provider/wls_ohsserver/wls_ohsserver.rb
+++ b/lib/puppet/provider/wls_ohsserver/wls_ohsserver.rb
@@ -1,0 +1,138 @@
+Puppet::Type.type(:wls_ohsserver).provide(:wls_ohsserver) do
+
+  def self.instances
+    []
+  end
+
+  def ohsserver_control(action)
+    Puppet.debug "ohs server action: #{action}"
+
+    domain_name                 = resource[:domain_name]
+    domain_path                 = resource[:domain_path]
+    name                        = resource[:server_name]
+    user                        = resource[:os_user]
+    weblogic_home_dir           = resource[:weblogic_home_dir]
+    weblogic_user               = resource[:weblogic_user]
+    weblogic_password           = resource[:weblogic_password]
+    nodemanager_address         = resource[:nodemanager_address]
+    nodemanager_port            = resource[:nodemanager_port]
+    nodemanager_secure_listener = resource[:nodemanager_secure_listener]
+    jsse_enabled                = resource[:jsse_enabled]
+    custom_trust                = resource[:custom_trust]
+    trust_keystore_file         = resource[:trust_keystore_file]
+    trust_keystore_passphrase   = resource[:trust_keystore_passphrase]
+    extra_arguments             = resource[:extra_arguments]
+
+    Puppet.debug "ohs server custom trust: #{custom_trust}"
+
+    if "#{custom_trust}" == 'true'
+      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} -Dweblogic.security.TrustKeyStore=CustomTrust -Dweblogic.security.CustomTrustKeyStoreFileName=#{trust_keystore_file} -Dweblogic.security.CustomTrustKeystorePassPhrase=#{trust_keystore_passphrase} #{extra_arguments}"
+    else
+      config = "-Dweblogic.ssl.JSSEEnabled=#{jsse_enabled} -Dweblogic.security.SSL.enableJSSE=#{jsse_enabled} #{extra_arguments}"
+    end
+
+    base_path = "#{weblogic_home_dir}/../oracle_common"
+
+    if action == :start
+      wls_action = "nmStart(serverName=\"#{name}\", serverType=\"OHS\")"
+    else
+      wls_action = "nmKill(serverName=\"#{name}\", serverType=\"OHS\")"
+    end
+
+    if "#{nodemanager_secure_listener}" == 'true'
+      nm_protocol = 'ssl'
+    else
+      nm_protocol = 'plain'
+    end
+
+    command = "#{base_path}/common/bin/wlst.sh -skipWLSModuleScanning <<-EOF
+nmConnect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"#{nodemanager_address}\",#{nodemanager_port},\"#{domain_name}\",\"#{domain_path}\",\"#{nm_protocol}\")
+#{wls_action}
+nmDisconnect()
+EOF"
+
+    command2 = "#{base_path}/common/bin/wlst.sh -skipWLSModuleScanning <<-EOF
+nmConnect(\"#{weblogic_user}\",\"xxxxx\",\"#{nodemanager_address}\",#{nodemanager_port},\"#{domain_name}\",\"#{domain_path}\",\"#{nm_protocol}\")
+#{wls_action}
+nmDisconnect()
+EOF"
+
+    Puppet.info "ohs server action: #{action} with command #{command2} and CONFIG_JVM_ARGS=#{config}"
+    kernel = Facter.value(:kernel)
+    su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
+        
+    if Puppet.features.root?
+      output = `su #{su_shell} - #{user} -c 'export CONFIG_JVM_ARGS="#{config}";#{command}'`
+    else
+      output = `export CONFIG_JVM_ARGS="#{config}";#{command}`
+    end
+    
+    Puppet.info "ohs server result: #{output}"
+  end
+
+  def ohsserver_status
+    domain_name                 = resource[:domain_name]
+    name                        = resource[:server_name]
+    user                        = resource[:os_user]
+    domain_path                 = resource[:domain_path]
+    nodemanager_address         = resource[:nodemanager_address]
+    nodemanager_port            = resource[:nodemanager_port]
+    nodemanager_secure_listener = resource[:nodemanager_secure_listener]
+    weblogic_home_dir           = resource[:weblogic_home_dir]
+    weblogic_user               = resource[:weblogic_user]
+    weblogic_password           = resource[:weblogic_password]
+
+    if "#{nodemanager_secure_listener}" == 'true'
+      nm_protocol = 'ssl'
+    else
+      nm_protocol = 'plain'
+    end
+
+    kernel = Facter.value(:kernel)
+
+    ps_bin = (kernel != 'SunOS' || (kernel == 'SunOS' && Facter.value(:kernelrelease) == '5.11')) ? '/bin/ps' : '/usr/ucb/ps'
+    ps_arg = kernel == 'SunOS' ? 'awwx' : '-ef'
+
+    command = "#{weblogic_home_dir}/common/bin/wlst.sh -skipWLSModuleScanning <<-EOF
+nmConnect(\"#{weblogic_user}\",\"#{weblogic_password}\",\"#{nodemanager_address}\",#{nodemanager_port},\"#{domain_name}\",\"#{domain_path}\",\"#{nm_protocol}\")
+nmServerStatus(serverName=\"#{name}\", serverType=\"OHS\")
+exit()
+EOF"
+
+    su_shell = kernel == 'Linux' ? '-s /bin/bash' : ''
+    output = `su #{su_shell} - #{user} -c '#{command}'`
+    Puppet.debug output
+    output.each_line do |li|
+      unless li.nil?
+        if li.include? 'RUNNING'
+          Puppet.debug 'found target'
+          return 'Found'
+        end
+      end
+    end
+    'NotFound'
+  end
+
+  def start
+    ohsserver_control :start
+  end
+
+  def stop
+    ohsserver_control :stop
+  end
+
+  def restart
+    ohsserver_control :stop
+    ohsserver_control :start
+  end
+
+  def status
+    output  = ohsserver_status
+    Puppet.debug "ohsserver_status output #{output}"
+    if output == 'Found'
+      return :start
+    else
+      return :stop
+    end
+  end
+end

--- a/lib/puppet/type/wls_adminserver.rb
+++ b/lib/puppet/type/wls_adminserver.rb
@@ -49,16 +49,6 @@ module Puppet
       EOT
     end
 
-    newparam(:ohs_standalone_server) do
-      desc <<-EOT
-        Flag to determinate if the server is a OHS standalone server.
-      EOT
-
-      newvalues(:true, :false)
-
-      defaultto :false
-    end
-
     newparam(:domain_name) do
       desc <<-EOT
         The weblogic domain name.

--- a/lib/puppet/type/wls_ohsserver.rb
+++ b/lib/puppet/type/wls_ohsserver.rb
@@ -1,0 +1,171 @@
+module Puppet
+  Type.newtype(:wls_ohsserver) do
+    desc 'control the ohs server state like running,stop,restart'
+
+    newproperty(:ensure) do
+      desc 'Whether to do something.'
+
+      newvalue(:start, :event => :ohsserver_running) do
+        unless :refreshonly == true
+          provider.start
+        end
+      end
+
+      newvalue(:stop, :event => :ohsserver_stop) do
+        unless :refreshonly == true
+          provider.stop
+        end
+      end
+
+      aliasvalue(:running, :start)
+      aliasvalue(:abort, :stop)
+
+      def retrieve
+        provider.status
+      end
+
+      def sync
+        event = super()
+        # rubocop:disable all
+        if property = @resource.property(:enable)
+          val = property.retrieve
+          property.sync unless property.safe_insync?(val)
+        end
+        # rubocop:enable all
+        event
+      end
+    end
+
+    newparam(:name) do
+      desc <<-EOT
+        The title.
+      EOT
+      isnamevar
+    end
+
+    newparam(:server_name) do
+      desc <<-EOT
+        The ohs server name.
+      EOT
+    end
+
+    newparam(:domain_name) do
+      desc <<-EOT
+        The weblogic domain name.
+      EOT
+    end
+
+    newparam(:domain_path) do
+      desc <<-EOT
+        The full domain path.
+      EOT
+    end
+
+    newparam(:os_user) do
+      desc <<-EOT
+        The weblogic operating system user.
+      EOT
+    end
+
+    newparam(:weblogic_home_dir) do
+      desc <<-EOT
+        The weblogic home folder.
+      EOT
+    end
+
+    newparam(:weblogic_user) do
+      desc <<-EOT
+        The weblogic user.
+      EOT
+    end
+
+    newparam(:weblogic_password) do
+      desc <<-EOT
+        The weblogic user password.
+      EOT
+    end
+
+    newparam(:jdk_home_dir) do
+      desc <<-EOT
+        The jdk home dir.
+      EOT
+    end
+
+    newparam(:nodemanager_address) do
+      desc <<-EOT
+        The nodemanager address.
+      EOT
+    end
+
+    newparam(:nodemanager_port) do
+      desc <<-EOT
+        The nodemanager port.
+      EOT
+    end
+
+    newparam(:nodemanager_secure_listener) do
+      desc <<-EOT
+        The nodemanager secure listener true or false.
+      EOT
+
+      newvalues(:true, :false)
+
+      defaultto :true
+    end
+
+    newparam(:jsse_enabled) do
+      desc <<-EOT
+        The jsse enabled.
+      EOT
+      newvalues(:true, :false)
+
+      defaultto :false
+    end
+
+    newparam(:custom_trust) do
+      desc <<-EOT
+        The custom trust enabled.
+      EOT
+      newvalues(:true, :false)
+
+      defaultto :false
+    end
+
+    newparam(:trust_keystore_file) do
+      desc <<-EOT
+        The trust keystore full path.
+      EOT
+    end
+
+    newparam(:trust_keystore_passphrase) do
+      desc <<-EOT
+        The trust keystore password.
+      EOT
+
+    end
+
+    newparam(:extra_arguments) do
+      desc <<-EOT
+        The extra java argument like -Dweblogic.security.SSL.minimumProtocolVersion=TLSv1.
+      EOT
+
+    end
+
+    newparam(:refreshonly) do
+      desc <<-EOT
+        The command should only be run as a
+        refresh mechanism for when a dependent object is changed.
+      EOT
+
+      newvalues(:true, :false)
+
+      defaultto :false
+    end
+
+    def refresh
+      Puppet.info 'wls_ohsserver refresh'
+      provider.restart
+    end
+
+  end
+end

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -61,7 +61,6 @@ define orawls::control (
       trust_keystore_file         => $trust_keystore_file,
       trust_keystore_passphrase   => $trust_keystore_passphrase,
       extra_arguments             => $extra_arguments,
-      ohs_standalone_server       => false,
     }
   }
   elsif $server_type == 'ohs_standalone' {

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -42,9 +42,7 @@ define orawls::control (
 
   $domain_dir = "${domains_dir}/${domain_name}"
 
-  if $server_type == 'admin' or $server_type == 'ohs_standalone' {
-    $ohs_standalone_server = ($server_type == 'ohs_standalone')
-
+  if $server_type == 'admin' {
     wls_adminserver{"${title}:AdminServer":
       ensure                      => $action,   #running|start|abort|stop
       server_name                 => $server,
@@ -63,7 +61,28 @@ define orawls::control (
       trust_keystore_file         => $trust_keystore_file,
       trust_keystore_passphrase   => $trust_keystore_passphrase,
       extra_arguments             => $extra_arguments,
-      ohs_standalone_server       => $ohs_standalone_server,
+      ohs_standalone_server       => false,
+    }
+  }
+  elsif $server_type == 'ohs_standalone' {
+    wls_ohsserver{"${title}:AdminServer":
+      ensure                      => $action,   #running|start|abort|stop
+      server_name                 => $server,
+      domain_name                 => $domain_name,
+      domain_path                 => $domain_dir,
+      os_user                     => $os_user,
+      weblogic_home_dir           => $weblogic_home_dir,
+      weblogic_user               => $weblogic_user,
+      weblogic_password           => $weblogic_password,
+      jdk_home_dir                => $jdk_home_dir,
+      nodemanager_address         => $adminserver_address,
+      nodemanager_port            => $nodemanager_port,
+      nodemanager_secure_listener => $nodemanager_secure_listener,
+      jsse_enabled                => $jsse_enabled,
+      custom_trust                => $custom_trust,
+      trust_keystore_file         => $trust_keystore_file,
+      trust_keystore_passphrase   => $trust_keystore_passphrase,
+      extra_arguments             => $extra_arguments,
     }
   }
   else {


### PR DESCRIPTION
These changes move control of a OHS Standalone server from wls_adminserver provider to a new one, wls_ohsserver. This was done initially because `adminserver_status` method (https://github.com/biemond/biemond-orawls/blob/master/lib/puppet/provider/wls_adminserver/wls_adminserver.rb#L95) doesn't verify ohs process status, and I think that it's better create a new provider specific to OHS Standalone than put another `if` block.