### PR TITLE
Modify bsu patching so it is possible use same patch in multiple WLS …

### DIFF
--- a/manifests/bsu.pp
+++ b/manifests/bsu.pp
@@ -62,7 +62,7 @@ define orawls::bsu (
       user      => $os_user,
       group     => $os_group,
       logoutput => false,
-      before    => Bsu_patch[$patch_id],
+      before    => Bsu_patch["${middleware_home_dir}:${patch_id}"],
     }
 
     if ( $version == 1111 ) {
@@ -74,7 +74,7 @@ define orawls::bsu (
     exec { "change memory params for ${patch_file}":
       command   => "sed -e's/MEM_ARGS=\"-Xms256m -Xmx512m\"/MEM_ARGS=\"-Xms256m -Xmx1024m -XX:-UseGCOverheadLimit\"/g' ${middleware_home_dir}/utils/bsu/bsu.sh > ${download_dir}/bsu.sh && mv ${download_dir}/bsu.sh ${middleware_home_dir}/utils/bsu/bsu.sh;chmod +x ${middleware_home_dir}/utils/bsu/bsu.sh",
       unless    => "grep 'MEM_ARGS=\"-Xms256m -Xmx1024m -XX:-UseGCOverheadLimit\"' ${middleware_home_dir}/utils/bsu/bsu.sh",
-      before    => Bsu_patch[$patch_id],
+      before    => Bsu_patch["${middleware_home_dir}:${patch_id}"],
       path      => $exec_path,
       user      => $os_user,
       group     => $os_group,
@@ -89,11 +89,11 @@ define orawls::bsu (
       user      => $os_user,
       group     => $os_group,
       logoutput => $log_output,
-      require   => Bsu_patch[$patch_id],
+      require   => Bsu_patch["${middleware_home_dir}:${patch_id}"],
     }
   }
 
-  bsu_patch{ $patch_id:
+  bsu_patch{ "${middleware_home_dir}:${patch_id}":
     ensure              => $ensure,
     os_user             => $os_user,
     middleware_home_dir => $middleware_home_dir,

--- a/spec/defines/bsu_spec.rb
+++ b/spec/defines/bsu_spec.rb
@@ -15,7 +15,7 @@ describe 'orawls::bsu', :type => :define do
                   :patch_file           => 'p17572726_1036_Generic.zip',
                   :source               => 'puppet:///middleware',
                 }}
-    let(:title) {'FCX7'}
+    let(:title) {'/opt/oracle/middleware11gR1:FCX7'}
     let(:facts) {{ :operatingsystem => 'CentOS' ,
                    :kernel          => 'Linux',
                    :osfamily        => 'RedHat' }}
@@ -38,13 +38,13 @@ describe 'orawls::bsu', :type => :define do
       it {
            should contain_exec("extract p17572726_1036_Generic.zip").with({
              'command'  => 'unzip -o /install/p17572726_1036_Generic.zip -d /opt/oracle/middleware11gR1/utils/bsu/cache_dir',
-           }).that_comes_before('Bsu_patch[FCX7]')
+           }).that_comes_before('Bsu_patch[/opt/oracle/middleware11gR1:FCX7]')
          }
     end
 
     describe "install BSU" do
       it {
-           should contain_bsu_patch("FCX7").with({
+           should contain_bsu_patch("/opt/oracle/middleware11gR1:FCX7").with({
              'ensure'               => 'present',
              'middleware_home_dir'  => '/opt/oracle/middleware11gR1',
              'os_user'              => 'oracle',
@@ -68,7 +68,7 @@ describe 'orawls::bsu', :type => :define do
                   :patch_file           => 'p17572726_1036_Generic.zip',
                   :source               => '/mnt',
                 }}
-    let(:title) {'FCX7'}
+    let(:title) {'/opt/oracle/middleware11gR1:FCX7'}
     let(:facts) {{ :operatingsystem => 'CentOS' ,
                    :kernel          => 'Linux',
                    :osfamily        => 'RedHat' }}
@@ -83,13 +83,13 @@ describe 'orawls::bsu', :type => :define do
       it {
            should contain_exec("extract p17572726_1036_Generic.zip").with({
              'command'  => 'unzip -o /mnt/p17572726_1036_Generic.zip -d /opt/oracle/middleware11gR1/utils/bsu/cache_dir',
-           }).that_comes_before('Bsu_patch[FCX7]')
+           }).that_comes_before('Bsu_patch[/opt/oracle/middleware11gR1:FCX7]')
          }
     end
 
     describe "install BSU" do
       it {
-           should contain_bsu_patch("FCX7").with({
+           should contain_bsu_patch("/opt/oracle/middleware11gR1:FCX7").with({
              'ensure'               => 'present',
              'middleware_home_dir'  => '/opt/oracle/middleware11gR1',
              'os_user'              => 'oracle',


### PR DESCRIPTION
…instances

bsu.pp, bsu_spec.rb:
Use "${middleware_home_dir}:${patch_id}" as patch name so it is possible to use same
patch in differenct instancies of WLS. See changes related to opatch around commit
'd12d868c985c2fb3a83411f0fd226643751b5542' (2015-10-21).

Provider bsu_patch:
Rename variable patchName to patch_name to be consistent with other variable names
Use patch_id in commands. Patch_id is created from patch_name based on change in bsu.pp
In method status use patch_name so name of patch is visible, not just patch_id