### PR TITLE
Add '.DS_Store' to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 spec/reports
 pkg
 spec/fixtures
+.DS_Store


### PR DESCRIPTION
Prevents `.DS_Store` files being uploaded to the forge.
https://docs.puppet.com/puppet/latest/reference/modules_publishing.html#set-files-to-be-ignored

This is most noticable when two different modules both have `.DS_Store`
files under the module's `lib` directory.  Plugin-sync flips between the
different copies each time puppet is run.