### PR TITLE
Changing indentation from "2" to "4" in wls_exec statements

### DIFF
--- a/lib/puppet/provider/wls_exec/wlst.rb
+++ b/lib/puppet/provider/wls_exec/wlst.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:wls_exec).provide(:sqlplus) do
       statement = File.read(file_name)
     end
 
-    statement = statement.indent(2)
+    statement = statement.indent(4)
     environment = { 'action' => 'execute', 'type' => 'wls_exec' }
     output = wlst template('puppet:///modules/orawls/providers/wls_exec/execute.py.erb', binding), environment
     Puppet.debug(output) if resource.logoutput == :true

--- a/lib/puppet/type/wls_exec/statement.rb
+++ b/lib/puppet/type/wls_exec/statement.rb
@@ -32,7 +32,7 @@ newproperty(:statement) do
       fail "File #{file_name} doesn't exist. " unless File.exists?(file_name)
       statement = File.read(file_name)
     end
-    statement = statement.indent(2)
+    statement = statement.indent(4)
     environment = { 'action' => 'execute', 'type' => 'wls_exec' }
     output = wlst template('puppet:///modules/orawls/providers/wls_exec/execute.py.erb', binding), environment
     !output.empty?


### PR DESCRIPTION
Previous indentation configuration was conflicting with "files/providers/wls_exec/execute.py.erb". For example:

```puppet
  wls_exec { "Cluster ${cluster_name} MaxStuckThreadTime":
    statement => "@/tmp/MaxStuckThreadTime-${cluster_name}-statement.py",
    unless    => "@/tmp/MaxStuckThreadTime-${cluster_name}-unless.py",
  }
```

generates python scripts like this:

```python
# MaxStuckThreadTime-EJB_CLUSTER_01-unless.py
# check the domain else we need to skip this (done in wls_access.rb)
real_domain='default'

try:
    puppet = open("/tmp/wlstScript.out", "w")
    print >>puppet, "output" # This is the header for the conversion

  # => should be indented with 4 spaces
  try:
      cd('/Clusters/EJB_CLUSTER_01/OverloadProtection/EJB_CLUSTER_01/ServerFailureTrigger/EJB_CLUSTER_01')
  
      if cmo.getMaxStuckThreadTime() != 120:
          print('MissingMaxStuckThreadTime')
  except:
      print('MissingMaxStuckThreadTime')
  # until here

    puppet.close()
    report_back_success()
except:
    report_back_error()
```

This way, wls_exec execution was always failing. Same happens with inline statements:

```puppet
  wls_exec { "Test ${cluster_name}":
    statement => "print('teeeest')",
  }
```

```python
# check the domain else we need to skip this (done in wls_access.rb)
real_domain='default'

try:
    puppet = open("/tmp/wlstScript.out", "w")
    print >>puppet, "output" # This is the header for the conversion

  # => should be indented with 4 spaces
  print('teeeest')

    puppet.close()
    report_back_success()
except:
    report_back_error()
```