### PR TITLE
wls_directory_structure: absent if domains_dir or apps_dir are absent

### DIFF
--- a/lib/puppet/type/wls_directory_structure.rb
+++ b/lib/puppet/type/wls_directory_structure.rb
@@ -17,17 +17,22 @@ module Puppet
       end
 
       def retrieve
-        oracle_base     = resource[:oracle_base_dir]
-        ora_inventory   = resource[:ora_inventory_dir]
-        download_folder = resource[:download_dir]
-
-        if File.exist?(oracle_base) && File.exist?(ora_inventory) && File.exist?(download_folder)
-          :present
-        else
-          :absent
+        [
+          :download_dir,
+          :ora_inventory_dir,
+          :oracle_base_dir,
+          :wls_apps_dir,
+          :wls_domains_dir,
+        ].map do |resourceSymbol|
+          resource[resourceSymbol]
+        end.map do |directory|
+          if !directory.nil? && !File.exist?(directory)
+            return :absent
+          end
         end
-      end
 
+        return :present
+      end
     end
 
     newparam(:oracle_base_dir) do


### PR DESCRIPTION
Prior to this commit, the wls_directory_structure type would be
considered present whenever all of the following were present:
  - oracle_base_dir
  - ora_inventory_dir
  - download_dir

But the type also defines two other directories, albeit optionally:
  - wls_apps_dir
  - wls_domains_dir
These directories weren't checked to make sure they're present, if
defined in the resource itself. From now on, they'll be checked, and if
either of those directories don't exist, they'll be recreated.