### PR TITLE
Update provider_specific.rb

### DIFF
--- a/lib/puppet/type/wls_authentication_provider/provider_specific.rb
+++ b/lib/puppet/type/wls_authentication_provider/provider_specific.rb
@@ -55,7 +55,11 @@ newproperty(:provider_specific) do
   #
   munge do | value_hash|
     value_hash.each do | key, value|
-      value_hash[key.to_s] = value.to_s
+      if (value==nil or value=='')
+        value_hash[key.to_s] = nil
+      else
+        value_hash[key.to_s] = value.to_s
+      end
     end
     value_hash
   end


### PR DESCRIPTION
Hi,

We are working with biemond-orawls (v1.0.53).

We have an application that runs on Weblogic and we use Puppet and Orawls to deploy it and manage it.

For this application we configure a wls_authentication_provider and we noticed that when deploying multiple times the same project we always have a change notified by puppet apply on one parameter even if the parameter is already set with the relevant value. All other parameters are not complaining of any change.

This is what we get on each time:

Notice: /Stage[main]/App_wls_auth_provider::Create_wls_auth_provider/Wls_authentication_provider[AppDemoDomain/AppAuthenticator]/provider_specific: Changed property Parameter2 from to .

When debug it I saw that the return value of Parameter2 is null:

Create_wls_auth_provider/Wls_authentication_provider[AppDemoDomain/AppAuthenticator]/provider_specific:
from
{"Parameter1"=>"ERROR", "Parameter2"=>nil}
to
{"Parameter1"=>"ERROR", "Parameter2"=>""}



This is our hiera file:

wls_authentication_provider:
  '%{hiera(''domain_name'')}/AppAuthenticator':
    ensure: present
    control_flag: SUFFICIENT
    providerclassname: com.app.APPCustomAuthenticator
    provider_specific:
      Parameter1: ERROR
      Parameter2: ''
    order: '0