### PR TITLE
Add support for JMS High Availability

### DIFF
--- a/files/providers/wls_jdbc_persistence_store/create_modify.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/create_modify.py.erb
@@ -9,6 +9,9 @@ prefix_name    = '<%= prefix_name %>'
 target         = '<%= target %>'
 targettype     = '<%= targettype %>'
 
+migration_policy = '<%= migration_policy %>'
+distribution_policy = '<%= distribution_policy %>'
+
 edit()
 startEdit()
 
@@ -21,6 +24,12 @@ try:
     cmo.setDataSource(getMBean('/SystemResources/'+datasource))
     set_attribute_value('PrefixName', prefix_name, use_default_value_when_empty)
     set('Targets', jarray.array([ObjectName('com.bea:Name='+target+',Type='+targettype)], ObjectName))
+
+    if migration_policy:
+        set_attribute_value('MigrationPolicy', migration_policy, use_default_value_when_empty)
+
+    if distribution_policy:
+        set_attribute_value('DistributionPolicy', distribution_policy, use_default_value_when_empty)
 
     save()
     activate()

--- a/files/providers/wls_jdbc_persistence_store/index.py.erb
+++ b/files/providers/wls_jdbc_persistence_store/index.py.erb
@@ -1,8 +1,8 @@
 
 
-m = ls('/JDBCStores',returnMap='true')
+f = open_file("name;datasource;prefix_name;migration_policy;distribution_policy;target;targettype;domain")
 
-f = open_file("name;datasource;prefix_name;target;targettype;domain")
+m = ls('/JDBCStores',returnMap='true')
 for token in m:
     print '___'+token+'___'
     cd('/JDBCStores/'+token)
@@ -11,9 +11,17 @@ for token in m:
     datasource = datasourceObject.getKeyProperty('Name')
 
     prefix_name = get('PrefixName')
+    migration_policy = ''
+    distribution_policy = ''
 
+    try:
+       migration_policy = get('MigrationPolicy')
+       distribution_policy = get('DistributionPolicy')
+    except:
+       pass
+       
     target, targetType = retrieve_target_list('/JDBCStores/'+token)
 
-    add_index_entry(f, [domain+'/'+token,datasource,prefix_name,','.join(target),','.join(targetType),domain])
+    add_index_entry(f, [domain+'/'+token,datasource,prefix_name,migration_policy,distribution_policy,','.join(target),','.join(targetType),domain])
 f.close()
 report_back_success()

--- a/lib/puppet/type/wls_jdbc_persistence_store.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store.rb
@@ -46,6 +46,9 @@ module Puppet
     property :target
     property :targettype
 
+    property :distribution_policy
+    property :migration_policy
+
     add_title_attributes(:jdbc_persistence_name) do
       /^((.*?\/)?(.*)?)$/
     end

--- a/lib/puppet/type/wls_jdbc_persistence_store/distribution_policy.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store/distribution_policy.rb
@@ -1,0 +1,10 @@
+newproperty(:distribution_policy) do
+  include EasyType
+
+  desc 'The JDBC persistent store distribution policy'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['distribution_policy']
+  end
+
+end

--- a/lib/puppet/type/wls_jdbc_persistence_store/migration_policy.rb
+++ b/lib/puppet/type/wls_jdbc_persistence_store/migration_policy.rb
@@ -1,0 +1,10 @@
+newproperty(:migration_policy) do
+  include EasyType
+
+  desc 'The JDBC persistent store migration policy'
+
+  to_translate_to_resource do | raw_resource |
+    raw_resource['migration_policy']
+  end
+
+end


### PR DESCRIPTION
I've added DistributionPolicy and MigrationPolicy to wls_jdbc_persistence_store. This allows a singleton JMS server to be automatically migrated if the node fails.