### PR TITLE
Update index.py.erb

### DIFF
--- a/files/providers/wls_datasource/index.py.erb
+++ b/files/providers/wls_datasource/index.py.erb
@@ -79,16 +79,16 @@ for token in m:
             xapropertiesCur = ''
 
             cd('/JDBCSystemResources/' + token + '/JDBCResource/' + token + '/JDBCXAParams/' + token)
-            xapropertiesarray = ls('', returnMap='true')
+            xapropertiesarray = ls(returnMap='true')
 
             for xaproperty in xapropertiesarray:
 
                 try:
-                    val = str(get(xaproperty))
-
-                    if xaproperty == 'isSet' or xaproperty == 'unSet':
-                        break
-                    elif len(xapropertiesCur) == len(xapropertiesarray) -1:
+                    if xaproperty != 'isSet' and  xaproperty != 'unSet': 
+                    	val = str(get(xaproperty))
+                    else:
+                        continue
+                    if len(xapropertiesCur) == len(xapropertiesarray) -1:
                         xapropertiesCur += xaproperty + '=' + val
                     else:
                         xapropertiesCur += xaproperty + '=' + val + ','


### PR DESCRIPTION
fix issue related to wls_datasource xaproperties not idempotent
I have tested it and the below issue was solved:

when running twice data source configuration the xaproperties shown as changed although there was no change

Notice:
..../xaproperties: xaproperties changed [] to 'RollbackLocalTxUponConnClose=0 RecoverOnlyOnce=0 KeepLogicalConnOpenOnRelease=0 KeepXaConnTillTxComplete=1 XaTransactionTimeout=0 XaRetryIntervalSeconds=60 XaRetryDurationSeconds=0 ResourceHealthMonitoring=1 NewXaConnForCommit=0 XaSetTransactionTimeout=0 XaEndOnlyOnce=0 NeedTxCtxOnClose=0'