### PR TITLE
Allow setting pack command option -managed

### DIFF
--- a/manifests/packdomain.pp
+++ b/manifests/packdomain.pp
@@ -23,6 +23,7 @@ define orawls::packdomain (
   String $os_group            = $::orawls::weblogic::os_group,
   String $download_dir        = $::orawls::weblogic::download_dir,
   Boolean $log_output         = $::orawls::weblogic::log_output,
+  Boolean $managed            = false,
 )
 {
 
@@ -39,7 +40,7 @@ define orawls::packdomain (
   }
 
   $exec_path = "${jdk_home_dir}/bin:${lookup('orawls::exec_path')}"
-  $packCommand = "${bin_dir} -domain=${domains_dir}/${domain_name} -template=${download_dir}/domain_${domain_name}.jar -template_name=domain_${domain_name} -log=${download_dir}/domain_${domain_name}.log -log_priority=INFO"
+  $packCommand = "${bin_dir} -domain=${domains_dir}/${domain_name} -template=${download_dir}/domain_${domain_name}.jar -template_name=domain_${domain_name} -managed=${managed} -log=${download_dir}/domain_${domain_name}.log -log_priority=INFO"
 
   exec { "pack domain ${domain_name} ${title}":
     command     => $packCommand,


### PR DESCRIPTION
https://docs.oracle.com/cd/E13179_01/common/docs92/pack/commands.html

-managed={true\|false} | Specifies whether the template is to be used to create Managed Servers on remote machines. The default is false.When this parameter is set to true, a Managed Server template is created that contains a minimal set of files, including SerializedSystemIni.dat,config.xml, and nm_password.properties. It also includes a domain.properties file that is unique to the Managed Server template.Applications and certain application initialization files are not included.The resulting template can be used to create Managed Servers on remote machines.
-- | --


