### PR TITLE
Check config.xml instead of domain_dir for domain creation

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -728,8 +728,8 @@ define orawls::domain (
     exec { "execwlst ${domain_name} ${title}":
       command     => "${wlstPath}/wlst.sh domain_${domain_name}.py",
       environment => ["JAVA_HOME=${jdk_home_dir}"],
-      unless      => "/usr/bin/test -e ${domain_dir}",
-      creates     => $domain_dir,
+      #unless      => "/usr/bin/test -e ${domain_dir}",
+      creates     => "${domain_dir}/config/config.xml",
       cwd         => $download_dir,
       require     => [File["domain.py ${domain_name} ${title}"],
                       File["${download_dir}/utils.py"],


### PR DESCRIPTION
Hi!

I some cases when de directory is already created, for example if this directory is  FS mounted, puppet doesn't launch the domain creation.

To skip this situtation, we are checking config.xml file created by all domains.


