### PR TITLE
add logrotation dir

### DIFF
--- a/files/providers/wls_server/create.py.erb
+++ b/files/providers/wls_server/create.py.erb
@@ -22,6 +22,7 @@ log_file_min_size           = '<%= log_file_min_size %>'
 log_filecount               = '<%= log_filecount %>'
 log_rotate_logon_startup    = '<%= log_rotate_logon_startup %>'
 log_rotationtype            = '<%= log_rotationtype %>'
+log_rotationdir             = '<%= log_rotationdir %>'
 log_number_of_files_limited = '<%= log_number_of_files_limited %>'
 log_redirect_stderr_to_server = '<%= log_redirect_stderr_to_server %>'
 log_redirect_stdout_to_server = '<%= log_redirect_stdout_to_server %>'
@@ -153,6 +154,7 @@ try:
     cd('/Servers/'+name+'/Log/'+name)
     set_attribute_value('FileName', logFilename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileCount', log_filecount, use_default_value_when_empty)
     set_attribute_value('NumberOfFilesLimited', log_number_of_files_limited, use_default_value_when_empty)
@@ -169,6 +171,7 @@ try:
     set_attribute_value('FileCount', log_http_file_count, use_default_value_when_empty)
     set_attribute_value('FileName', log_http_Filename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileMinSize', log_file_min_size, use_default_value_when_empty)
     set_attribute_value('LogFileFormat', log_http_format_type, use_default_value_when_empty)
@@ -179,6 +182,7 @@ try:
     cd('/Servers/'+name+'/DataSource/'+name+'/DataSourceLogFile/'+name)
     set_attribute_value('FileName', log_datasource_Filename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileCount', log_filecount, use_default_value_when_empty)
     set_attribute_value('NumberOfFilesLimited', log_number_of_files_limited, use_default_value_when_empty)

--- a/files/providers/wls_server/index.py.erb
+++ b/files/providers/wls_server/index.py.erb
@@ -2,7 +2,7 @@
 cd("/")
 m = ls('/Servers',returnMap='true')
 
-f = open_file("name;listenaddress;listenport;logintimeout;ssllistenport;sslenabled;sslhostnameverificationignored;sslhostnameverifier;two_way_ssl;client_certificate_enforced;useservercerts;machine;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_number_of_files_limited;tunnelingenabled;log_http_filename;log_http_format;log_http_format_type;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size;log_redirect_stderr_to_server;log_redirect_stdout_to_server;restart_max;log_http_file_count;log_http_number_of_files_limited;bea_home;weblogic_plugin_enabled;listenportenabled;auto_restart;autokillwfail;server_parameters;frontendhost;frontendhttpport;frontendhttpsport;log_date_pattern;log_stdout_severity;log_log_file_severity", tmp_script)
+f = open_file("name;listenaddress;listenport;logintimeout;ssllistenport;sslenabled;sslhostnameverificationignored;sslhostnameverifier;two_way_ssl;client_certificate_enforced;useservercerts;machine;logfilename;log_file_min_size;log_filecount;log_rotate_logon_startup;log_rotationtype;log_rotationdir;log_number_of_files_limited;tunnelingenabled;log_http_filename;log_http_format;log_http_format_type;log_datasource_filename;classpath;arguments;jsseenabled;domain;custom_identity;custom_identity_keystore_filename;trust_keystore_file;custom_identity_alias;default_file_store;max_message_size;log_redirect_stderr_to_server;log_redirect_stdout_to_server;restart_max;log_http_file_count;log_http_number_of_files_limited;bea_home;weblogic_plugin_enabled;listenportenabled;auto_restart;autokillwfail;server_parameters;frontendhost;frontendhttpport;frontendhttpsport;log_date_pattern;log_stdout_severity;log_log_file_severity", tmp_script)
 for token in m:
   print '___'+token+'___'
   cd('/Servers/'+token)
@@ -53,6 +53,7 @@ for token in m:
   cd('/Servers/'+token+'/Log/'+token)
   logfilename                   = get_attribute_value('FileName')
   log_rotationtype              = get_attribute_value('RotationType')
+  log_rotationdir               = get_attribute_value('LogFileRotationDir')
   log_rotate_logon_startup      = get_attribute_value('RotateLogOnStartup')
   log_number_of_files_limited   = get_attribute_value('NumberOfFilesLimited')
   log_filecount                 = get_attribute_value('FileCount')
@@ -84,7 +85,7 @@ for token in m:
       if token2:
          machine = token2
 
-  add_index_entry(f, [domain+'/'+token, listenAddress, listenPort, logintimeout, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, sslhostnameverifier, two_way_ssl, client_certificate_enforced, useservercerts, machine, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_number_of_files_limited, tunnelingenabled,log_http_filename,log_http_format,log_http_format_type,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size, log_redirect_stderr_to_server, log_redirect_stdout_to_server, restart_max, log_http_file_count,log_http_number_of_files_limited, bea_home, weblogic_plugin_enabled, listenPortEnabled,auto_restart,autokillwfail,server_parameters,frontendhost,frontendhttpport,frontendhttpsport,log_date_pattern, log_stdout_severity, log_log_file_severity])
+  add_index_entry(f, [domain+'/'+token, listenAddress, listenPort, logintimeout, sslListenPort, sslEnabled, sslHostnameVerificationIgnored, sslhostnameverifier, two_way_ssl, client_certificate_enforced, useservercerts, machine, logfilename,log_file_min_size,log_filecount,log_rotate_logon_startup,log_rotationtype,log_rotationdir,log_number_of_files_limited, tunnelingenabled,log_http_filename,log_http_format,log_http_format_type,log_datasource_filename, classpath, arguments,jsseEnabled,domain,custom_identity,custom_identity_keystore_filename,trust_keystore_file,custom_identity_alias,default_file_store,max_message_size, log_redirect_stderr_to_server, log_redirect_stdout_to_server, restart_max, log_http_file_count,log_http_number_of_files_limited, bea_home, weblogic_plugin_enabled, listenPortEnabled,auto_restart,autokillwfail,server_parameters,frontendhost,frontendhttpport,frontendhttpsport,log_date_pattern, log_stdout_severity, log_log_file_severity])
 
 f.close()
 report_back_success()

--- a/files/providers/wls_server/modify.py.erb
+++ b/files/providers/wls_server/modify.py.erb
@@ -46,6 +46,7 @@ log_file_min_size             = '<%= log_file_min_size %>'
 log_filecount                 = '<%= log_filecount %>'
 log_rotate_logon_startup      = '<%= log_rotate_logon_startup %>'
 log_rotationtype              = '<%= log_rotationtype %>'
+log_rotationdir               = '<%= log_rotationdir %>'
 log_number_of_files_limited   = '<%= log_number_of_files_limited %>'
 log_redirect_stderr_to_server = '<%= log_redirect_stderr_to_server %>'
 log_redirect_stdout_to_server = '<%= log_redirect_stdout_to_server %>'
@@ -183,6 +184,7 @@ try:
     cd('/Servers/'+name+'/Log/'+name)
     set_attribute_value('FileName', logFilename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileCount', log_filecount, use_default_value_when_empty)
     set_attribute_value('NumberOfFilesLimited', log_number_of_files_limited, use_default_value_when_empty)
@@ -199,6 +201,7 @@ try:
     set_attribute_value('FileCount', log_http_file_count, use_default_value_when_empty)
     set_attribute_value('FileName', log_http_Filename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileMinSize', log_file_min_size, use_default_value_when_empty)
     set_attribute_value('LogFileFormat', log_http_format_type, use_default_value_when_empty)
@@ -208,6 +211,7 @@ try:
     cd('/Servers/'+name+'/DataSource/'+name+'/DataSourceLogFile/'+name)
     set_attribute_value('FileName', log_datasource_Filename, use_default_value_when_empty)
     set_attribute_value('RotationType', log_rotationtype, use_default_value_when_empty)
+    set_attribute_value('LogFileRotationDir', log_rotationdir, use_default_value_when_empty)
     set_attribute_value('RotateLogOnStartup', log_rotate_logon_startup, use_default_value_when_empty)
     set_attribute_value('FileCount', log_filecount, use_default_value_when_empty)
     set_attribute_value('NumberOfFilesLimited', log_number_of_files_limited, use_default_value_when_empty)

--- a/lib/puppet/type/wls_server.rb
+++ b/lib/puppet/type/wls_server.rb
@@ -71,6 +71,7 @@ module Puppet
     property :log_number_of_files_limited
     property :log_filecount
     property :log_rotationtype
+    property :log_rotationdir
     property :log_rotate_logon_startup
     property :log_datasource_filename
     property :log_redirect_stdout_to_server

--- a/lib/puppet/type/wls_server/log_rotationdir.rb
+++ b/lib/puppet/type/wls_server/log_rotationdir.rb
@@ -1,0 +1,12 @@
+newproperty(:log_rotationdir) do
+  include EasyType
+
+  desc 'The log rotation dir of the server'
+
+  defaultto ''
+
+  to_translate_to_resource do | raw_resource|
+    raw_resource['log_rotationdir']
+  end
+
+end


### PR DESCRIPTION
hi @biemond ,

I would like to merge this.  The reason to have this is we have separate file system for logs and if we enable log rotation type, the log rotation dir is set to 'logs/archives' by default which is causing to move the archive logs to different file system. We want all logs to be in the same file system.