### PR TITLE
Adding parameters to set TEMP and SOA Tablespace for alle RCU Schemas

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -745,7 +745,7 @@ define orawls::domain (
       user        => $os_user,
       group       => $os_group,
     }
-  
+
     if ($domain_template == 'ohs_standalone') {
       ## Create OHS standalone config directory
       file { "${domain_dir}/config/fmwconfig/components/OHS/ohs1/mod_wl_ohs.d":
@@ -971,6 +971,5 @@ define orawls::domain (
         group   => $os_group,
       }
     }
-  
   }
 }

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -85,6 +85,8 @@
 # @param domain_password the domain password
 # @param webtier_enabled webtier template extension add to the domain
 # @param rcu_database_url the rcu database url
+# @param rcu_tablespace the tablespace used for the rco
+# @param rcu_temp_tablespace the tablespace used for the rco
 # @param repository_sys_user the rcu sys username
 # @param repository_sys_password the rcu sys passoword
 # @param log_dir the full path to the log directory
@@ -134,6 +136,8 @@ define orawls::domain (
   Boolean $log_output                                     = $::orawls::weblogic::log_output,
   Optional[String] $repository_database_url               = undef, #jdbc:oracle:thin:@192.168.50.5:1521:XE
   Optional[String] $rcu_database_url                      = undef, #localhost:1521:XE"
+  Optional[String] $rcu_temp_tablespace                   = undef, #TEMP
+  Optional[String] $rcu_tablespace                        = undef, #SOA_INFRA
   Optional[String] $repository_prefix                     = 'DEV',
   Optional[String] $repository_password                   = undef,
   Optional[String] $repository_sys_user                   = 'sys',
@@ -714,6 +718,8 @@ define orawls::domain (
           rcu_action                  => 'create',
           rcu_jdbc_url                => $repository_database_url,
           rcu_database_url            => $rcu_database_url,
+          rcu_temp_tablespace         => $rcu_temp_tablespace,
+          rcu_tablespace              => $rcu_tablespace,
           rcu_sys_user                => $repository_sys_user,
           rcu_sys_password            => $repository_sys_password,
           rcu_prefix                  => $repository_prefix,
@@ -739,7 +745,7 @@ define orawls::domain (
       user        => $os_user,
       group       => $os_group,
     }
-
+  
     if ($domain_template == 'ohs_standalone') {
       ## Create OHS standalone config directory
       file { "${domain_dir}/config/fmwconfig/components/OHS/ohs1/mod_wl_ohs.d":
@@ -965,5 +971,6 @@ define orawls::domain (
         group   => $os_group,
       }
     }
+  
   }
 }

--- a/manifests/utils/rcu.pp
+++ b/manifests/utils/rcu.pp
@@ -35,6 +35,8 @@ define orawls::utils::rcu(
   String $rcu_password                                 = undef,
   String $rcu_sys_user                                 = 'sys',
   String $rcu_sys_password                             = undef,
+  Optional[String] $rcu_temp_tablespace                = undef, #temp
+  Optional[String] $rcu_tablespace                     = undef, #soa_infra
 ){
 
   # TODO: create and use function sanitize_string (fmw.pp, duplicated code)
@@ -50,36 +52,47 @@ define orawls::utils::rcu(
     }
   }
 
+  if $rcu_temp_tablespace == undef {
+    $rcu_temp_tablespace_cmd  = ""
+  } else {
+    $rcu_temp_tablespace_cmd  = "-tempTablespace ${rcu_temp_tablespace}"
+  }  
+  if $rcu_tablespace == undef {
+    $rcu_tablespace_cmd  = ""
+  } else {
+    $rcu_tablespace_cmd  = "-tablespace ${rcu_tablespace}"
+  }  
+
   if $fmw_product == 'adf' {
     if $version >= 1221 {
-      $components = '-component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS -component WLS -component STB '
+      $components = "-component MDS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WLS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component STB ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
       $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
     }
     else {
-      $components = '-component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS -component WLS -component UCSCC '
+      $components = "-component MDS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WLS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSCC ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
       $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
     }
   }
   elsif $fmw_product == 'soa' {
     if $version >= 1221 {
-      $components = '-component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS -component WLS -component STB -component UCSUMS -component ESS -component SOAINFRA '
+      $components = "-component MDS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WLS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component STB ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSUMS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component ESS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component SOAINFRA ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
       $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
     }
     else {
-      $components = '-component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS -component WLS -component UCSCC -component UCSUMS -component UMS -component ESS -component SOAINFRA -component MFT '
+      $components = "-component MDS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WLS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSCC ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSUMS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UMS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component ESS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component SOAINFRA ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component MFT ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
       $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
     }
   }
   elsif $fmw_product == 'mft' {
-    $components = '-component MDS -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS -component WLS -component UCSCC -component MFT -component UCSUMS -component ESS'
+    $components = "-component MDS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WLS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSCC ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component MFT ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component UCSUMS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component ESS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
     $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
   }
   elsif $fmw_product == 'wcs' {
-    $components = '-component STB -component OPSS -component WCSITES -component WCSITESVS -component IAU -component IAU_APPEND -component IAU_VIEWER'
+    $components = "-component STB ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WCSITES ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component WCSITESVS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
     $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
   }
   elsif $fmw_product == 'forms' {
-    $components = '-component STB -component IAU -component IAU_APPEND -component IAU_VIEWER -component OPSS'
+    $components = "-component STB ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_APPEND ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd} -component IAU_VIEWER ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}-component OPSS ${rcu_temp_tablespace_cmd} ${rcu_tablespace_cmd}"
     $componentsPasswords = [$rcu_password, $rcu_password, $rcu_password, $rcu_password, $rcu_password]
   }
   else {
@@ -114,7 +127,7 @@ define orawls::utils::rcu(
   elsif $rcu_action == 'delete' {
     $action = '-dropRepository'
   }
-
+  
   wls_rcu{ "${rcu_prefix}_${sanitised_title}":
     ensure       => $rcu_action,
     statement    => "${oracle_fmw_product_home_dir}/bin/rcu -silent ${action} -databaseType ORACLE -connectString ${rcu_database_url} -dbUser ${rcu_sys_user} -dbRole SYSDBA -schemaPrefix ${rcu_prefix} ${components} -f < ${download_dir}/rcu_passwords_${fmw_product}_${rcu_action}_${rcu_prefix}_${sanitised_title}.txt",

--- a/manifests/utils/rcu.pp
+++ b/manifests/utils/rcu.pp
@@ -53,15 +53,15 @@ define orawls::utils::rcu(
   }
 
   if $rcu_temp_tablespace == undef {
-    $rcu_temp_tablespace_cmd  = ""
+    $rcu_temp_tablespace_cmd  = ''
   } else {
     $rcu_temp_tablespace_cmd  = "-tempTablespace ${rcu_temp_tablespace}"
-  }  
+  }
   if $rcu_tablespace == undef {
-    $rcu_tablespace_cmd  = ""
+    $rcu_tablespace_cmd  = ''
   } else {
     $rcu_tablespace_cmd  = "-tablespace ${rcu_tablespace}"
-  }  
+  }
 
   if $fmw_product == 'adf' {
     if $version >= 1221 {
@@ -127,7 +127,7 @@ define orawls::utils::rcu(
   elsif $rcu_action == 'delete' {
     $action = '-dropRepository'
   }
-  
+
   wls_rcu{ "${rcu_prefix}_${sanitised_title}":
     ensure       => $rcu_action,
     statement    => "${oracle_fmw_product_home_dir}/bin/rcu -silent ${action} -databaseType ORACLE -connectString ${rcu_database_url} -dbUser ${rcu_sys_user} -dbRole SYSDBA -schemaPrefix ${rcu_prefix} ${components} -f < ${download_dir}/rcu_passwords_${fmw_product}_${rcu_action}_${rcu_prefix}_${sanitised_title}.txt",


### PR DESCRIPTION
Example:

domain_instances:
  "soa_domain":
    version:                  *wls_version
    domain_template:          "soa"
...    log_output:               true
    rcu_database_url:         "%{hiera('wls_rcu_database_url')}"
    rcu_temp_tablespace:      'TEMP'
    rcu_tablespace:           'SOAINFRA'
....