### PR TITLE
fix: raise exception on opatch fail

### DIFF
--- a/lib/puppet/provider/wls_opatch/prefetching.rb
+++ b/lib/puppet/provider/wls_opatch/prefetching.rb
@@ -34,6 +34,9 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
       output = `export ORACLE_HOME=#{oracle_product_home_dir};#{oracle_product_home_dir}/OPatch/opatch #{command} -oh #{oracle_product_home_dir} #{jre_specfied} #{orainst}`
     end
     Puppet.info output
+    if $?.exitstatus != 0
+      raise "Error while executing opatch command"
+    end
     output
   end
 
@@ -53,6 +56,9 @@ Puppet::Type.type(:wls_opatch).provide(:prefetching) do
       raw_list = `#{oracle_product_home_dir}/OPatch/opatch lsinventory -oh #{oracle_product_home_dir} -invPtrLoc #{orainst_dir}/oraInst.loc`
     end
     Puppet.info raw_list
+    if $?.exitstatus != 0
+      raise "Error while executing opatch command"
+    end
     patch_ids = raw_list.scan(/Patch\s.(\d+)\s.*:\sapplied on/).flatten
     patch_ids.collect{|p| "#{oracle_product_home_dir}:#{p}"}
   end


### PR DESCRIPTION
When executing command using `command` mechanism and command fails no exception is raised. User is responsible to check result for example '$?.exitstatus' and do appropriate action.

Without explicit check after wls_opatch failed puppet task returned success!