### PR TITLE
New parameter ora_inventory_dir

### DIFF
--- a/manifests/weblogic.pp
+++ b/manifests/weblogic.pp
@@ -8,6 +8,7 @@
 #     version                   => 12212,
 #     filename                  => 'fmw_12.2.1.2.0_wls.jar',
 #     jdk_home_dir              => '/usr/java/latest',
+#     ora_inventory_dir         => '/opt/oracle',
 #     oracle_base_home_dir      => "/opt/oracle",
 #     middleware_home_dir       => "/opt/oracle/middleware12c",
 #     weblogic_home_dir         => "/opt/oracle/middleware12c/wlserver",
@@ -21,6 +22,7 @@
 # 
 # @param version Weblogic version like 1036, 1111, 1213 or 12212
 # @param filename the weblogic jar file like wls1036_generic.jar or fmw_12.2.1.2.0_wls.jar
+# @param ora_inventory_dir full path to the Oracle Inventory location directory. If not specfied, it defaults to oracle_base_home_dir (for example /opt/oracle or /u01/app/oracle). If you use the biemond-oradb module, you must set it to oracle_base_home_dir/.. (for example /opt or /u01/app)
 # @param oracle_base_home_dir base directory of the oracle installation, it will contain the default Oracle inventory and the middleware home
 # @param middleware_home_dir directory of the Oracle software inside the oracle base directory
 # @param weblogic_home_dir directory of the WebLogic software inside the middleware directory
@@ -43,6 +45,7 @@
 class orawls::weblogic (
   Integer $version                    = lookup('orawls::default_version'),
   String $filename                    = undef,
+  Optional[String] $ora_inventory_dir = undef, # /opt/oracle
   String $oracle_base_home_dir        = undef, # /opt/oracle
   String $middleware_home_dir         = undef, # /opt/oracle/middleware11gR1
   Optional[String] $weblogic_home_dir = undef, # /opt/oracle/middleware11gR1/wlserver
@@ -67,6 +70,7 @@ class orawls::weblogic (
   orawls::weblogic_type{'base':
     version                   => $version,
     filename                  => $filename,
+    ora_inventory_dir         => $ora_inventory_dir,
     oracle_base_home_dir      => $oracle_base_home_dir,
     middleware_home_dir       => $middleware_home_dir,
     weblogic_home_dir         => $weblogic_home_dir,

--- a/manifests/weblogic_type.pp
+++ b/manifests/weblogic_type.pp
@@ -8,6 +8,7 @@
 #     version                   => 12212,
 #     filename                  => 'fmw_12.2.1.2.0_wls.jar',
 #     jdk_home_dir              => '/usr/java/latest',
+#     ora_inventory_dir         => '/opt/oracle',
 #     oracle_base_home_dir      => "/opt/oracle",
 #     middleware_home_dir       => "/opt/oracle/middleware12c",
 #     weblogic_home_dir         => "/opt/oracle/middleware12c/wlserver",
@@ -19,6 +20,7 @@
 # 
 # @param version Weblogic version like 1036, 1111, 1213 or 12212
 # @param filename the weblogic jar file like wls1036_generic.jar or fmw_12.2.1.2.0_wls.jar
+# @param ora_inventory_dir full path to the Oracle Inventory location directory. If not specfied, it defaults to oracle_base_home_dir (for example /opt/oracle or /u01/app/oracle). If you use the biemond-oradb module, you must set it to oracle_base_home_dir/.. (for example /opt or /u01/app)
 # @param oracle_base_home_dir base directory of the oracle installation, it will contain the default Oracle inventory and the middleware home
 # @param middleware_home_dir directory of the Oracle software inside the oracle base directory
 # @param weblogic_home_dir directory of the WebLogic software inside the middleware directory
@@ -41,6 +43,7 @@
 define orawls::weblogic_type (
   Integer $version                    = lookup('orawls::default_version'),
   String $filename                    = undef, # wls1036_generic.jar|wls1211_generic.jar|wls_121200.jar|wls_121300.jar|oepe-wls-indigo-installer-11.1.1.8.0.201110211138-10.3.6-linux32.bin
+  Optional[String] $ora_inventory_dir = undef, # /opt/oracle
   String $oracle_base_home_dir        = undef, # /opt/oracle
   String $middleware_home_dir         = undef, # /opt/oracle/middleware11gR1
   Optional[String] $weblogic_home_dir = undef, # /opt/oracle/middleware11gR1/wlserver
@@ -106,7 +109,12 @@ define orawls::weblogic_type (
   }
 
   $exec_path         = "${jdk_home_dir}/bin:${lookup('orawls::exec_path')}"
-  $ora_inventory_dir = "${oracle_base_home_dir}/oraInventory"
+  
+  if $ora_inventory_dir == undef {
+    $ora_inventory = "${oracle_base_home_dir}/oraInventory" 
+  } else {
+    $ora_inventory = "${ora_inventory_dir}/oraInventory"
+  }
 
   Exec {
     logoutput => $log_output,
@@ -146,7 +154,7 @@ define orawls::weblogic_type (
   }
 
   orawls::utils::orainst { "weblogic orainst ${title}":
-    ora_inventory_dir => $ora_inventory_dir,
+    ora_inventory_dir => $ora_inventory,
     os_group          => $os_group,
     orainstpath_dir   => $orainstpath_dir
   }

--- a/manifests/weblogic_type.pp
+++ b/manifests/weblogic_type.pp
@@ -109,9 +109,9 @@ define orawls::weblogic_type (
   }
 
   $exec_path         = "${jdk_home_dir}/bin:${lookup('orawls::exec_path')}"
-  
+
   if $ora_inventory_dir == undef {
-    $ora_inventory = "${oracle_base_home_dir}/oraInventory" 
+    $ora_inventory = "${oracle_base_home_dir}/oraInventory"
   } else {
     $ora_inventory = "${ora_inventory_dir}/oraInventory"
   }

--- a/manifests/weblogic_type.pp
+++ b/manifests/weblogic_type.pp
@@ -162,7 +162,7 @@ define orawls::weblogic_type (
   wls_directory_structure{"weblogic structure ${title}":
     ensure            => present,
     oracle_base_dir   => $oracle_base_home_dir,
-    ora_inventory_dir => $ora_inventory_dir,
+    ora_inventory_dir => $ora_inventory,
     download_dir      => $download_dir,
     wls_domains_dir   => $domains_dir,
     wls_apps_dir      => $apps_dir,

--- a/spec/classes/weblogic_remote_spec.rb
+++ b/spec/classes/weblogic_remote_spec.rb
@@ -233,4 +233,40 @@ describe 'orawls::weblogic', :type => :class do
 
   end
 
+  describe "weblogic local 12.1.2 install inventory" do
+    let(:params){{
+                  :version              => 1212,
+                  :download_dir         => '/install',
+                  :filename             => 'wls_121200.jar',
+                  :os_user              => 'oracle',
+                  :os_group             => 'dba',
+                  :middleware_home_dir  => '/opt/oracle/middleware12c',
+                  :weblogic_home_dir    => '/opt/oracle/middleware12c/wlserver',
+                  :oracle_base_home_dir => '/opt/oracle',
+                  :ora_inventory_dir    => '/opt',
+                  :jdk_home_dir         => '/usr/java/jdk1.7.0_45',
+                  :remote_file          => false,
+                  :puppet_download_mnt_point               => '/software',
+                  :log_output           => true,
+
+                }}
+    let(:facts) {{ :operatingsystem => 'CentOS' ,
+                   :kernel          => 'Linux',
+                   :osfamily => 'RedHat' }}
+    
+    describe "WebLogic structure" do
+      it do
+        should contain_wls_directory_structure("weblogic structure base").with({
+             'oracle_base_dir'      => '/opt/oracle',
+             'ora_inventory_dir'    => '/opt/oraInventory',
+             'os_group'             => 'dba',
+             'os_user'              => 'oracle',
+             'download_dir'         => '/install',
+             'wls_domains_dir'      => nil,
+             'wls_apps_dir'         => nil,
+           })
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
An optional parameter ora_inventory_dir is added to specify an alternative path for the oraInventory.
When the parameter is not specified, the default location for the inventory is oracle_base_home_dir/oraInventory, so for example /opt/oracle/oraInventory or /u01/app/oracle/oraInventory.
When you specify the parameter ora_inventory_dir the inventory goes to ora_inventory_dir/oraInventory. 

Examples:
ora_inventory_dir=/opt => /opt/oraInventory
ora_inventory_dir=/u01/app => /u01/app/oraInventory

This change is intended to make the biemond-orawls module compatible with the biemond-oradb module. To be compatible, set the ora_inventory_dir equal to oracle_base_home_dir/.. (that is one directory higher than the oracle_base_home_dir).