### PR TITLE
rename systemctl reload declaration to avoid module conflicts

### DIFF
--- a/manifests/urandomfix.pp
+++ b/manifests/urandomfix.pp
@@ -31,7 +31,7 @@ class orawls::urandomfix() {
             path    => $path,
           }
 
-          exec { 'systemctl-daemon-reload':
+          exec { 'urandomfix-systemctl-daemon-reload':
             command     => 'systemctl --system daemon-reload',
             path        => $path,
             subscribe   => Exec['set urandom /lib/systemd/system/rngd.service'],
@@ -42,7 +42,7 @@ class orawls::urandomfix() {
           service { 'rngd':
             ensure  => 'running',
             enable  => true,
-            require => Exec['systemctl-daemon-reload'],
+            require => Exec['urandomfix-systemctl-daemon-reload'],
           }
         }
         '6': {


### PR DESCRIPTION
systemd puppet module and dependent projects may fail due to duplicate declaration for systemctl-daemon-reload in urandom fix.

Example:

Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: 

Exec[systemctl-daemon-reload] is already declared in file /etc/puppetlabs/code/environments/development/modules/orawls/manifests/urandomfix.pp:39; cannot redeclare at /etc/puppetlabs/code/environments/development/modules/systemd/manifests/systemctl/daemon_reload.pp:5 at /etc/puppetlabs/code/environments/development/modules/systemd/manifests/systemctl/daemon_reload.pp:5:3 at /etc/puppetlabs/code/environments/development/modules/prometheus/manifests/node_exporter.pp:147 on node 