### PR TITLE
Modify the logic for when the memory params are changed

### DIFF
--- a/manifests/bsu.pp
+++ b/manifests/bsu.pp
@@ -73,7 +73,7 @@ define orawls::bsu (
 
     exec { "change memory params for ${patch_file}":
       command   => "sed -e's/MEM_ARGS=\"-Xms256m -Xmx512m\"/MEM_ARGS=\"-Xms256m -Xmx1024m -XX:-UseGCOverheadLimit\"/g' ${middleware_home_dir}/utils/bsu/bsu.sh > ${download_dir}/bsu.sh && mv ${download_dir}/bsu.sh ${middleware_home_dir}/utils/bsu/bsu.sh;chmod +x ${middleware_home_dir}/utils/bsu/bsu.sh",
-      unless    => "grep 'MEM_ARGS=\"-Xms256m -Xmx1024m -XX:-UseGCOverheadLimit\"' ${middleware_home_dir}/utils/bsu/bsu.sh",
+      onlyif    => "grep 'MEM_ARGS=\"-Xms256m -Xmx512m\"' ${middleware_home_dir}/utils/bsu/bsu.sh",
       before    => Bsu_patch["${middleware_home_dir}:${patch_id}"],
       path      => $exec_path,
       user      => $os_user,


### PR DESCRIPTION
The current exec for changing the memory params will run unless the
ending condition is met. However, the command itself is dependant upon a
particular start condition. This leads to a loop where if the MEM_ARGS
don't match the 'unless', it will run the exec and the exec won't change
anything because sed isn't able to match anything (though it completes
successfully).

This PR will fix that by changing the 'unless' to an 'onlyif', and
making the condition of that 'onlyif' the same as the search string that
sed is looking for in the exec.