### PR TITLE
Weblogic SOA installation in SOLARIS forcing two compressed files

### DIFF
--- a/manifests/fmw.pp
+++ b/manifests/fmw.pp
@@ -743,7 +743,7 @@ define orawls::fmw(
     }
 
     if $facts['kernel'] == 'SunOS' {
-      if $version != 1213 {
+      if $version < 1213 {
         if $fmw_product == 'soa' {
           exec { "add -d64 oraparam.ini ${sanitised_title}":
             command   => "sed -e's/JRE_MEMORY_OPTIONS=\" -Xverify:none\"/JRE_MEMORY_OPTIONS=\"-d64 -Xverify:none\"/g' ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini > ${temp_dir}/soa.tmp && mv ${temp_dir}/soa.tmp ${download_dir}/${sanitised_title}/Disk1/install/${installDir}/oraparam.ini",

--- a/templates/nodemgr/nodemanager.properties.epp
+++ b/templates/nodemgr/nodemanager.properties.epp
@@ -1,7 +1,7 @@
 <%- |  String $weblogic_home_dir,
        String $jdk_home_dir,
        String $nodemanager_address,
-       Integer $nodemanager_port = 5556,
+       Integer $nodemanager_port,
        Boolean $nodemanager_secure_listener =true,
        Hash $properties_merged,
        String $nodeMgrLogDir,


### PR DESCRIPTION
As per the current logic in fmw.pp , it is expected to pass two compressed files for all versions other than 12.1.3, while installing in SOLARIS

This logic seems to be incorrect, as i am getting error for version 12.2.1.3

Please review the change and approve the pull request.